### PR TITLE
Add nutrition provider mocks and computations

### DIFF
--- a/packages/nutrition_kit/lib/nutrition_kit.dart
+++ b/packages/nutrition_kit/lib/nutrition_kit.dart
@@ -1,0 +1,8 @@
+library nutrition_kit;
+
+export 'src/nutrition_provider.dart';
+export 'src/composite_provider.dart';
+export 'src/compute/compute_nutrients.dart';
+export 'src/providers/open_food_facts_mock.dart';
+export 'src/providers/food_data_central_mock.dart';
+export 'src/providers/edamam_mock.dart';

--- a/packages/nutrition_kit/lib/src/composite_provider.dart
+++ b/packages/nutrition_kit/lib/src/composite_provider.dart
@@ -1,0 +1,168 @@
+import 'dart:collection';
+
+import 'package:core_kit/core_kit.dart';
+
+import 'data/seed_repository.dart';
+import 'nutrition_provider.dart';
+import 'providers/edamam_mock.dart';
+import 'providers/food_data_central_mock.dart';
+import 'providers/open_food_facts_mock.dart';
+
+/// Aggregates multiple nutrition providers and caches responses in-memory.
+class CompositeNutritionProvider implements NutritionProvider {
+  CompositeNutritionProvider({
+    List<NutritionProvider>? providers,
+    int cacheSize = 32,
+    Map<String, FoodItem>? manualCatalog,
+  })  : _providers = List<NutritionProvider>.unmodifiable(
+          providers ??
+              <NutritionProvider>[
+                OpenFoodFactsMockProvider(),
+                FoodDataCentralMockProvider(),
+                EdamamMockProvider(),
+              ],
+        ),
+        _lookupCache = _LruCache<String, FoodItem>(capacity: cacheSize),
+        _searchCache = _LruCache<String, List<FoodItem>>(capacity: cacheSize),
+        _nutrientCache = _LruCache<String, Nutrients>(capacity: cacheSize),
+        _manualCatalog = Map<String, FoodItem>.unmodifiable(
+          manualCatalog ??
+              _defaultManualCatalog(
+                SeedFoodRepository.instance,
+              ),
+        ) {
+    _manualById = Map<String, FoodItem>.unmodifiable({
+      for (final item in _manualCatalog.values) item.id: item,
+    });
+  }
+
+  final List<NutritionProvider> _providers;
+  final _LruCache<String, FoodItem> _lookupCache;
+  final _LruCache<String, List<FoodItem>> _searchCache;
+  final _LruCache<String, Nutrients> _nutrientCache;
+  final Map<String, FoodItem> _manualCatalog;
+  late final Map<String, FoodItem> _manualById;
+
+  static Map<String, FoodItem> _defaultManualCatalog(
+    SeedFoodRepository repository,
+  ) {
+    final map = <String, FoodItem>{};
+    final bread = repository.itemById(
+      '77777777-7777-7777-7777-777777777777',
+    );
+    if (bread != null) {
+      map['036000291452'] = bread;
+    }
+    return map;
+  }
+
+  @override
+  Future<FoodItem?> lookupByBarcode(String barcode) async {
+    final cached = _lookupCache.get(barcode);
+    if (cached != null) {
+      return cached;
+    }
+
+    for (final provider in _providers) {
+      final result = await provider.lookupByBarcode(barcode);
+      if (result != null) {
+        _lookupCache.set(barcode, result);
+        return result;
+      }
+    }
+
+    final manual = _manualCatalog[barcode];
+    if (manual != null) {
+      _lookupCache.set(barcode, manual);
+    }
+    return manual;
+  }
+
+  @override
+  Future<List<FoodItem>> searchFoods(String query) async {
+    final key = query.trim().toLowerCase();
+    final cached = _searchCache.get(key);
+    if (cached != null) {
+      return cached;
+    }
+
+    for (final provider in _providers) {
+      final result = await provider.searchFoods(query);
+      if (result.isNotEmpty) {
+        final copy = List<FoodItem>.unmodifiable(result);
+        _searchCache.set(key, copy);
+        return copy;
+      }
+    }
+
+    final manualMatches = _manualCatalog.values.where(
+      (item) => _matchesQuery(item, key),
+    ).toList(growable: false)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    final manualResult = List<FoodItem>.unmodifiable(manualMatches);
+    _searchCache.set(key, manualResult);
+    return manualResult;
+  }
+
+  @override
+  Future<Nutrients?> nutrientsFor(FoodItem item) async {
+    final cached = _nutrientCache.get(item.id);
+    if (cached != null) {
+      return cached;
+    }
+
+    for (final provider in _providers) {
+      final result = await provider.nutrientsFor(item);
+      if (result != null) {
+        _nutrientCache.set(item.id, result);
+        return result;
+      }
+    }
+
+    final manual = _manualById[item.id] ?? item;
+    _nutrientCache.set(item.id, manual.nutrients);
+    return manual.nutrients;
+  }
+
+  bool _matchesQuery(FoodItem item, String query) {
+    if (query.isEmpty) {
+      return true;
+    }
+    final name = item.name.toLowerCase();
+    if (name.contains(query)) {
+      return true;
+    }
+    for (final tag in item.tags) {
+      if (tag.toLowerCase().contains(query)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+class _LruCache<K, V> {
+  _LruCache({required this.capacity}) : assert(capacity > 0);
+
+  final int capacity;
+  final _store = LinkedHashMap<K, V>();
+
+  V? get(K key) {
+    if (!_store.containsKey(key)) {
+      return null;
+    }
+    final value = _store.remove(key)!;
+    _store[key] = value;
+    return value;
+  }
+
+  void set(K key, V value) {
+    if (_store.containsKey(key)) {
+      _store.remove(key);
+    } else if (_store.length >= capacity) {
+      final oldestKey = _store.keys.first;
+      _store.remove(oldestKey);
+    }
+    _store[key] = value;
+  }
+}

--- a/packages/nutrition_kit/lib/src/compute/compute_nutrients.dart
+++ b/packages/nutrition_kit/lib/src/compute/compute_nutrients.dart
@@ -1,0 +1,105 @@
+import 'package:core_kit/core_kit.dart';
+
+import '../data/seed_repository.dart';
+
+/// Computes the nutrient totals for a [FoodItem] given a [quantity] and [unit].
+Nutrients computeNutrients(
+  FoodItem item,
+  double quantity,
+  UnitType unit,
+) {
+  if (quantity <= 0) {
+    return const Nutrients();
+  }
+
+  final per100g = _per100gFor(item);
+  final grams = _quantityInGrams(quantity, unit, item);
+
+  if (per100g != null && grams != null) {
+    final factor = grams / 100;
+    return per100g.scale(factor);
+  }
+
+  final servings = _quantityInServings(quantity, unit, item);
+  return item.nutrients.scale(servings);
+}
+
+Nutrients? _per100gFor(FoodItem item) {
+  final repository = SeedFoodRepository.instance;
+  final seeded = repository.per100gFor(item.id);
+  if (seeded != null) {
+    return seeded;
+  }
+  if (_isWeightUnit(item.servingUnit) && item.servingSize > 0) {
+    final factor = 100 / item.servingSize;
+    return item.nutrients.scale(factor);
+  }
+  return null;
+}
+
+bool _isWeightUnit(UnitType unit) {
+  return unit == UnitType.gram || unit == UnitType.milliliter;
+}
+
+const Map<UnitType, double> _gramsPerUnit = <UnitType, double>{
+  UnitType.gram: 1.0,
+  UnitType.milliliter: 1.0,
+  UnitType.ounce: 28.3495,
+  UnitType.pound: 453.592,
+  UnitType.cup: 240.0,
+  UnitType.tablespoon: 15.0,
+  UnitType.teaspoon: 5.0,
+};
+
+double? _quantityInGrams(double quantity, UnitType unit, FoodItem item) {
+  final grams = _gramsPerUnit[unit];
+  if (grams != null) {
+    return quantity * grams;
+  }
+  if (unit == UnitType.serving &&
+      _isWeightUnit(item.servingUnit) &&
+      item.servingSize > 0) {
+    return quantity * item.servingSize;
+  }
+  if (unit == item.servingUnit &&
+      _gramsPerUnit.containsKey(unit) &&
+      item.servingSize > 0) {
+    return quantity * item.servingSize;
+  }
+  return null;
+}
+
+double _quantityInServings(double quantity, UnitType unit, FoodItem item) {
+  if (unit == UnitType.serving) {
+    return quantity;
+  }
+  if (unit == item.servingUnit) {
+    if (item.servingSize == 0) {
+      return 0;
+    }
+    return quantity / item.servingSize;
+  }
+
+  final grams = _quantityInGrams(quantity, unit, item);
+  if (grams != null &&
+      _isWeightUnit(item.servingUnit) &&
+      item.servingSize > 0) {
+    return grams / item.servingSize;
+  }
+
+  return quantity;
+}
+
+extension on Nutrients {
+  Nutrients scale(double factor) {
+    return Nutrients(
+      calories: calories * factor,
+      protein: protein * factor,
+      fat: fat * factor,
+      carbohydrates: carbohydrates * factor,
+      fiber: fiber * factor,
+      sugar: sugar * factor,
+      sodium: sodium * factor,
+    );
+  }
+}

--- a/packages/nutrition_kit/lib/src/data/seed_repository.dart
+++ b/packages/nutrition_kit/lib/src/data/seed_repository.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:core_kit/core_kit.dart';
+import 'package:path/path.dart' as p;
+
+/// Lightweight accessor around the shared seed data shipped with the project.
+class SeedFoodRepository {
+  SeedFoodRepository._() {
+    _loadSeedData();
+  }
+
+  static final SeedFoodRepository instance = SeedFoodRepository._();
+
+  late final Map<String, FoodItem> _itemsById;
+  late final Map<String, Nutrients> _per100gById;
+
+  List<FoodItem> get items => _itemsById.values.toList(growable: false);
+
+  FoodItem? itemById(String id) => _itemsById[id];
+
+  FoodItem? itemByName(String name) {
+    final lower = name.toLowerCase();
+    for (final item in _itemsById.values) {
+      if (item.name.toLowerCase() == lower) {
+        return item;
+      }
+    }
+    for (final item in _itemsById.values) {
+      if (item.name.toLowerCase().contains(lower)) {
+        return item;
+      }
+    }
+    return null;
+  }
+
+  Nutrients? per100gFor(String id) => _per100gById[id];
+
+  void _loadSeedData() {
+    final file = _resolveSeedFile();
+    if (file == null) {
+      throw StateError('Unable to locate seed_data.json');
+    }
+    final jsonData = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    final foods = jsonData['foodItems'] as List<dynamic>? ?? <dynamic>[];
+
+    _itemsById = <String, FoodItem>{};
+    _per100gById = <String, Nutrients>{};
+
+    for (final dynamic entry in foods) {
+      final foodJson = entry as Map<String, dynamic>;
+      final food = _parseFoodItem(foodJson);
+      _itemsById[food.id] = food;
+
+      final per100g = _derivePer100g(food);
+      if (per100g != null) {
+        _per100gById[food.id] = per100g;
+      }
+    }
+  }
+
+  File? _resolveSeedFile() {
+    final candidates = <String>[
+      p.join('packages', 'core_kit', 'seed', 'seed_data.json'),
+      p.join('..', 'core_kit', 'seed', 'seed_data.json'),
+      p.join('..', '..', 'core_kit', 'seed', 'seed_data.json'),
+      p.join('core_kit', 'seed', 'seed_data.json'),
+    ];
+
+    for (final candidate in candidates) {
+      final file = File(candidate);
+      if (file.existsSync()) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  FoodItem _parseFoodItem(Map<String, dynamic> json) {
+    final nutrientsJson = json['nutrients'] as Map<String, dynamic>? ?? <String, dynamic>{};
+    final tags = _stringList(json['tags']);
+    final allergens = _stringList(json['allergens']);
+
+    return FoodItem(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      nutrients: Nutrients(
+        calories: _toDouble(nutrientsJson['calories']),
+        protein: _toDouble(nutrientsJson['protein']),
+        fat: _toDouble(nutrientsJson['fat']),
+        carbohydrates: _toDouble(nutrientsJson['carbohydrates']),
+        fiber: _toDouble(nutrientsJson['fiber']),
+        sugar: _toDouble(nutrientsJson['sugar']),
+        sodium: _toDouble(nutrientsJson['sodium']),
+      ),
+      servingSize: _toDouble(json['servingSize']),
+      servingUnit: UnitType.values.byName(json['servingUnit'] as String),
+      tags: tags,
+      allergens: allergens,
+      brand: json['brand'] as String?,
+      description: json['description'] as String?,
+      imageUrl: json['imageUrl'] as String?,
+    );
+  }
+
+  Nutrients? _derivePer100g(FoodItem item) {
+    if (item.servingSize <= 0) {
+      return null;
+    }
+    if (item.servingUnit == UnitType.gram || item.servingUnit == UnitType.milliliter) {
+      final factor = 100 / item.servingSize;
+      return _scale(item.nutrients, factor);
+    }
+    return null;
+  }
+
+  double _toDouble(dynamic value) {
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value) ?? 0.0;
+    }
+    return 0.0;
+  }
+
+  List<String> _stringList(dynamic value) {
+    if (value is List<dynamic>) {
+      return value.map((dynamic entry) => entry.toString()).toList(growable: false);
+    }
+    return const <String>[];
+  }
+
+  Nutrients _scale(Nutrients nutrients, double factor) {
+    return Nutrients(
+      calories: nutrients.calories * factor,
+      protein: nutrients.protein * factor,
+      fat: nutrients.fat * factor,
+      carbohydrates: nutrients.carbohydrates * factor,
+      fiber: nutrients.fiber * factor,
+      sugar: nutrients.sugar * factor,
+      sodium: nutrients.sodium * factor,
+    );
+  }
+}

--- a/packages/nutrition_kit/lib/src/nutrition_provider.dart
+++ b/packages/nutrition_kit/lib/src/nutrition_provider.dart
@@ -1,0 +1,14 @@
+import 'package:core_kit/core_kit.dart';
+
+/// Contract for retrieving nutrition information from third party sources.
+abstract class NutritionProvider {
+  /// Looks up a food entry by [barcode]. Returns `null` when the provider does
+  /// not have a matching product in its catalog.
+  Future<FoodItem?> lookupByBarcode(String barcode);
+
+  /// Performs a text search for foods matching [query].
+  Future<List<FoodItem>> searchFoods(String query);
+
+  /// Retrieves the most up to date nutrient profile for [item].
+  Future<Nutrients?> nutrientsFor(FoodItem item);
+}

--- a/packages/nutrition_kit/lib/src/providers/edamam_mock.dart
+++ b/packages/nutrition_kit/lib/src/providers/edamam_mock.dart
@@ -1,0 +1,14 @@
+import '../data/seed_repository.dart';
+import 'seeded_provider.dart';
+
+/// Mock implementation that mirrors a subset of the Edamam food database.
+class EdamamMockProvider extends SeededMockProvider {
+  EdamamMockProvider({SeedFoodRepository? repository})
+      : super(
+          repository: repository,
+          barcodeToFoodId: const {
+            '9421902960000': '33333333-3333-3333-3333-333333333333',
+            '016000275233': '66666666-6666-6666-6666-666666666666',
+          },
+        );
+}

--- a/packages/nutrition_kit/lib/src/providers/food_data_central_mock.dart
+++ b/packages/nutrition_kit/lib/src/providers/food_data_central_mock.dart
@@ -1,0 +1,14 @@
+import '../data/seed_repository.dart';
+import 'seeded_provider.dart';
+
+/// Mock provider that mimics USDA FoodData Central responses.
+class FoodDataCentralMockProvider extends SeededMockProvider {
+  FoodDataCentralMockProvider({SeedFoodRepository? repository})
+      : super(
+          repository: repository,
+          barcodeToFoodId: const {
+            '078742300007': '22222222-2222-2222-2222-222222222222',
+            '041268000684': '55555555-5555-5555-5555-555555555555',
+          },
+        );
+}

--- a/packages/nutrition_kit/lib/src/providers/open_food_facts_mock.dart
+++ b/packages/nutrition_kit/lib/src/providers/open_food_facts_mock.dart
@@ -1,0 +1,15 @@
+import '../data/seed_repository.dart';
+import 'seeded_provider.dart';
+
+/// Mock implementation that emulates a subset of the Open Food Facts API.
+
+class OpenFoodFactsMockProvider extends SeededMockProvider {
+  OpenFoodFactsMockProvider({SeedFoodRepository? repository})
+      : super(
+          repository: repository,
+          barcodeToFoodId: const {
+            '8901234567890': '11111111-1111-1111-1111-111111111111',
+            '1234567890123': '44444444-4444-4444-4444-444444444444',
+          },
+        );
+}

--- a/packages/nutrition_kit/lib/src/providers/seeded_provider.dart
+++ b/packages/nutrition_kit/lib/src/providers/seeded_provider.dart
@@ -1,0 +1,83 @@
+import 'package:core_kit/core_kit.dart';
+
+import '../data/seed_repository.dart';
+import '../nutrition_provider.dart';
+
+abstract class SeededMockProvider implements NutritionProvider {
+  SeededMockProvider({
+    SeedFoodRepository? repository,
+    required Map<String, String> barcodeToFoodId,
+  })  : _repository = repository ?? SeedFoodRepository.instance,
+        _catalog = _buildCatalog(
+          repository ?? SeedFoodRepository.instance,
+          barcodeToFoodId,
+        ),
+        _itemsById = _buildById(
+          repository ?? SeedFoodRepository.instance,
+          barcodeToFoodId,
+        );
+
+  final SeedFoodRepository _repository;
+  final Map<String, FoodItem> _catalog;
+  final Map<String, FoodItem> _itemsById;
+
+  static Map<String, FoodItem> _buildCatalog(
+    SeedFoodRepository repository,
+    Map<String, String> barcodeToFoodId,
+  ) {
+    final map = <String, FoodItem>{};
+    barcodeToFoodId.forEach((barcode, foodId) {
+      final item = repository.itemById(foodId);
+      if (item != null) {
+        map[barcode] = item;
+      }
+    });
+    return map;
+  }
+
+  static Map<String, FoodItem> _buildById(
+    SeedFoodRepository repository,
+    Map<String, String> barcodeToFoodId,
+  ) {
+    final byId = <String, FoodItem>{};
+    barcodeToFoodId.forEach((_, foodId) {
+      final item = repository.itemById(foodId);
+      if (item != null) {
+        byId[item.id] = item;
+      }
+    });
+    return byId;
+  }
+
+  @override
+  Future<FoodItem?> lookupByBarcode(String barcode) async => _catalog[barcode];
+
+  @override
+  Future<List<FoodItem>> searchFoods(String query) async {
+    final normalized = query.trim().toLowerCase();
+    if (normalized.isEmpty) {
+      return _catalog.values.toList(growable: false);
+    }
+    final matches = _catalog.values.where((item) {
+      final name = item.name.toLowerCase();
+      if (name.contains(normalized)) {
+        return true;
+      }
+      for (final tag in item.tags) {
+        if (tag.toLowerCase().contains(normalized)) {
+          return true;
+        }
+      }
+      return false;
+    }).toList(growable: false);
+    matches.sort((a, b) => a.name.compareTo(b.name));
+    return matches;
+  }
+
+  @override
+  Future<Nutrients?> nutrientsFor(FoodItem item) async => _itemsById[item.id]?.nutrients;
+
+  Iterable<FoodItem> get catalog => _catalog.values;
+
+  SeedFoodRepository get repository => _repository;
+}

--- a/packages/nutrition_kit/pubspec.yaml
+++ b/packages/nutrition_kit/pubspec.yaml
@@ -7,7 +7,9 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  # Add package dependencies here.
+  core_kit:
+    path: ../core_kit
+  path: 1.9.0
 
 dev_dependencies:
-  # Add dev dependencies here.
+  test: 1.25.2

--- a/packages/nutrition_kit/test/nutrition_provider_test.dart
+++ b/packages/nutrition_kit/test/nutrition_provider_test.dart
@@ -1,0 +1,85 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:nutrition_kit/nutrition_kit.dart';
+import 'package:nutrition_kit/src/data/seed_repository.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CompositeNutritionProvider', () {
+    late CompositeNutritionProvider provider;
+
+    setUp(() {
+      provider = CompositeNutritionProvider();
+    });
+
+    test('lookupByBarcode queries providers in order', () async {
+      final quinoa = await provider.lookupByBarcode('8901234567890');
+      expect(quinoa, isNotNull);
+      expect(quinoa!.name, 'Quinoa');
+
+      final chicken = await provider.lookupByBarcode('078742300007');
+      expect(chicken, isNotNull);
+      expect(chicken!.name, 'Grilled Chicken Breast');
+
+      final avocado = await provider.lookupByBarcode('9421902960000');
+      expect(avocado, isNotNull);
+      expect(avocado!.name, 'Avocado');
+
+      final bread = await provider.lookupByBarcode('036000291452');
+      expect(bread, isNotNull);
+      expect(bread!.name, 'Whole Grain Bread');
+    });
+
+    test('searchFoods falls back between providers and manual data', () async {
+      final yogurtResults = await provider.searchFoods('greek');
+      expect(yogurtResults.map((item) => item.name), contains('Greek Yogurt'));
+
+      final berries = await provider.searchFoods('blueberries');
+      expect(berries.map((item) => item.name), contains('Blueberries'));
+
+      final bread = await provider.searchFoods('bread');
+      expect(bread.map((item) => item.name), contains('Whole Grain Bread'));
+    });
+  });
+
+  group('computeNutrients', () {
+    late SeedFoodRepository repository;
+
+    setUp(() {
+      repository = SeedFoodRepository.instance;
+    });
+
+    test('prefers per-100g data when available', () {
+      final quinoa = repository.itemById(
+        '11111111-1111-1111-1111-111111111111',
+      );
+      expect(quinoa, isNotNull);
+
+      final nutrients = computeNutrients(quinoa!, 200, UnitType.gram);
+      final caloriesPerGram = quinoa.nutrients.calories / quinoa.servingSize;
+      final proteinPerGram = quinoa.nutrients.protein / quinoa.servingSize;
+      expect(nutrients.calories, closeTo(caloriesPerGram * 200, 0.01));
+      expect(nutrients.protein, closeTo(proteinPerGram * 200, 0.01));
+    });
+
+    test('falls back to serving-based calculations', () {
+      final snack = FoodItem.create(
+        name: 'Trail Mix',
+        nutrients: const Nutrients(
+          calories: 220,
+          protein: 6,
+          fat: 12,
+          carbohydrates: 24,
+          fiber: 3,
+          sugar: 12,
+          sodium: 150,
+        ),
+        servingSize: 1,
+        servingUnit: UnitType.serving,
+      );
+
+      final nutrients = computeNutrients(snack, 2, UnitType.serving);
+      expect(nutrients.calories, 440);
+      expect(nutrients.protein, 12);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- define a `NutritionProvider` contract and composite provider with LRU caching plus manual fallbacks
- load seed nutrition data and expose seeded mock providers for OpenFoodFacts, FoodData Central, and Edamam
- add a nutrient computation helper along with tests that cover lookups, search results, and nutrient math

## Testing
- `dart test packages/nutrition_kit` *(fails: `dart` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc8bb20e0832f8811506535c9fd29