### PR TITLE
Add scanner feature screens and tests

### DIFF
--- a/packages/features/scanner/lib/confirm_food_screen.dart
+++ b/packages/features/scanner/lib/confirm_food_screen.dart
@@ -1,0 +1,387 @@
+import 'dart:math' as math;
+
+import 'package:core_kit/core_kit.dart';
+import 'package:data_kit/data_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:nutrition_kit/nutrition_kit.dart';
+
+/// Confirmation screen displayed after a barcode lookup resolves to a [FoodItem].
+class ConfirmFoodScreen extends StatefulWidget {
+  const ConfirmFoodScreen({
+    super.key,
+    required this.foodItem,
+    required this.mealRepository,
+    required this.mealType,
+    required this.nutritionProvider,
+  });
+
+  final FoodItem foodItem;
+  final MealRepository mealRepository;
+  final MealType mealType;
+  final CompositeNutritionProvider nutritionProvider;
+
+  @override
+  State<ConfirmFoodScreen> createState() => _ConfirmFoodScreenState();
+}
+
+class _ConfirmFoodScreenState extends State<ConfirmFoodScreen> {
+  static const double _quantityStep = 0.5;
+
+  late double _quantity;
+  late UnitType _unit;
+  bool _loadingNutrients = true;
+  bool _saving = false;
+  Nutrients? _nutrients;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _quantity = widget.foodItem.servingSize > 0
+        ? widget.foodItem.servingSize
+        : 1.0;
+    _unit = widget.foodItem.servingUnit;
+    _loadNutrients();
+  }
+
+  Future<void> _loadNutrients() async {
+    try {
+      final result = await widget.nutritionProvider.nutrientsFor(widget.foodItem);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _nutrients = result ?? widget.foodItem.nutrients;
+        _loadingNutrients = false;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _nutrients = widget.foodItem.nutrients;
+        _loadingNutrients = false;
+        _errorMessage =
+            'Impossibile aggiornare i valori nutrizionali. Verranno usati quelli disponibili.';
+      });
+    }
+  }
+
+  Future<void> _handleAdd() async {
+    if (_saving) {
+      return;
+    }
+
+    setState(() {
+      _saving = true;
+      _errorMessage = null;
+    });
+
+    try {
+      await widget.mealRepository.addIngredient(
+        mealType: widget.mealType,
+        item: widget.foodItem,
+        quantity: _quantity,
+        unit: _unit,
+      );
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).pop(true);
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _errorMessage =
+            'Non è stato possibile aggiungere l\'alimento al pasto. Riprova più tardi.';
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+        });
+      }
+    }
+  }
+
+  void _incrementQuantity() {
+    setState(() {
+      _quantity = _roundToStep(_quantity + _quantityStep);
+    });
+  }
+
+  void _decrementQuantity() {
+    setState(() {
+      _quantity = _roundToStep(math.max(0.1, _quantity - _quantityStep));
+    });
+  }
+
+  double _roundToStep(double value) {
+    final scaled = (value / _quantityStep).round();
+    final result = scaled * _quantityStep;
+    return result.clamp(0.1, 9999).toDouble();
+  }
+
+  Nutrients get _scaledNutrients {
+    final base = _nutrients ?? widget.foodItem.nutrients;
+    final serving = widget.foodItem.servingSize > 0
+        ? widget.foodItem.servingSize
+        : 1.0;
+    final factor = _quantity / serving;
+    return base.copyWith(
+      calories: base.calories * factor,
+      protein: base.protein * factor,
+      fat: base.fat * factor,
+      carbohydrates: base.carbohydrates * factor,
+      fiber: base.fiber * factor,
+      sugar: base.sugar * factor,
+      sodium: base.sodium * factor,
+    );
+  }
+
+  String get _portionDescription =>
+      '${_formatQuantity(_quantity)} ${_unitLabel(_unit).toLowerCase()}';
+
+  String _formatQuantity(double value) {
+    if (value % 1 == 0) {
+      return value.toStringAsFixed(0).replaceAll('.', ',');
+    }
+    return value.toStringAsFixed(1).replaceAll('.', ',');
+  }
+
+  String _unitLabel(UnitType unit) {
+    final name = unit.name.replaceAll('_', ' ');
+    return name[0].toUpperCase() + name.substring(1);
+  }
+
+  Widget _buildQuantityControls(ThemeData theme) {
+    return Row(
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceVariant,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.remove),
+                onPressed: _quantity <= 0.5 ? null : _decrementQuantity,
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  _formatQuantity(_quantity),
+                  style: theme.textTheme.titleMedium,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: _incrementQuantity,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: DropdownButtonFormField<UnitType>(
+            value: _unit,
+            decoration: const InputDecoration(
+              labelText: 'Unità',
+              border: OutlineInputBorder(),
+            ),
+            onChanged: (value) {
+              if (value != null) {
+                setState(() {
+                  _unit = value;
+                });
+              }
+            },
+            items: UnitType.values
+                .map(
+                  (unit) => DropdownMenuItem<UnitType>(
+                    value: unit,
+                    child: Text(_unitLabel(unit)),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildNutrientSummary(ThemeData theme) {
+    if (_loadingNutrients) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 32),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    final nutrients = _scaledNutrients;
+    final values = <_NutrientValue>[
+      _NutrientValue('Calorie', nutrients.calories, 'kcal'),
+      _NutrientValue('Proteine', nutrients.protein, 'g'),
+      _NutrientValue('Grassi', nutrients.fat, 'g'),
+      _NutrientValue('Carboidrati', nutrients.carbohydrates, 'g'),
+      _NutrientValue('Fibre', nutrients.fiber, 'g'),
+      _NutrientValue('Zuccheri', nutrients.sugar, 'g'),
+      _NutrientValue('Sodio', nutrients.sodium, 'mg'),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Valori nutrizionali (${_portionDescription})',
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 12),
+        ...values.map(
+          (value) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 6),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(value.label, style: theme.textTheme.bodyLarge),
+                Text(
+                  value.formatted,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Conferma alimento'),
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(24),
+          children: [
+            Text(
+              widget.foodItem.name,
+              style: theme.textTheme.headlineSmall,
+            ),
+            if (widget.foodItem.brand != null && widget.foodItem.brand!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  widget.foodItem.brand!,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            if (widget.foodItem.description != null &&
+                widget.foodItem.description!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 12),
+                child: Text(
+                  widget.foodItem.description!,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            const SizedBox(height: 24),
+            _buildQuantityControls(theme),
+            const SizedBox(height: 24),
+            _buildNutrientSummary(theme),
+            if (_errorMessage != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: Text(
+                  _errorMessage!,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.error,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: _saving ? null : _handleAdd,
+              child: _saving
+                  ? const SizedBox(
+                      height: 24,
+                      width: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Aggiungi al pasto'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NutrientValue {
+  _NutrientValue(this.label, this.value, this.suffix);
+
+  final String label;
+  final double value;
+  final String suffix;
+
+  String get formatted {
+    final formattedValue =
+        value.toStringAsFixed(value >= 100 ? 0 : 1).replaceAll('.', ',');
+    return '$formattedValue $suffix';
+  }
+}
+
+/// Abstraction over the persistence layer for meal entries.
+abstract class MealRepository {
+  Future<void> addIngredient({
+    required MealType mealType,
+    required FoodItem item,
+    required double quantity,
+    required UnitType unit,
+  });
+}
+
+/// Default implementation backed by the [MealEntryDao] from `data_kit`.
+class DataKitMealRepository implements MealRepository {
+  DataKitMealRepository(this._mealEntryDao);
+
+  final MealEntryDao _mealEntryDao;
+
+  @override
+  Future<void> addIngredient({
+    required MealType mealType,
+    required FoodItem item,
+    required double quantity,
+    required UnitType unit,
+  }) {
+    final ingredient = Ingredient.create(
+      item: item,
+      quantity: quantity,
+      unit: unit,
+    );
+
+    final entry = MealEntry.create(
+      mealType: mealType,
+      consumedAt: DateTime.now(),
+      ingredients: <Ingredient>[ingredient],
+    );
+
+    return _mealEntryDao.upsertMealEntry(entry);
+  }
+}

--- a/packages/features/scanner/lib/scanner_screen.dart
+++ b/packages/features/scanner/lib/scanner_screen.dart
@@ -1,0 +1,353 @@
+import 'dart:async';
+
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:nutrition_kit/nutrition_kit.dart';
+
+import 'confirm_food_screen.dart';
+
+/// Signature for providing a custom scanner widget in tests.
+typedef MobileScannerWidgetBuilder = Widget Function(
+  BuildContext context,
+  MobileScannerController controller,
+  void Function(BarcodeCapture capture) onDetect,
+);
+
+/// Full-screen barcode scanner that looks up products via [CompositeNutritionProvider].
+class ScannerScreen extends StatefulWidget {
+  const ScannerScreen({
+    super.key,
+    required this.mealRepository,
+    CompositeNutritionProvider? nutritionProvider,
+    this.mobileScannerBuilder,
+    this.mealType = MealType.snack,
+  }) : nutritionProvider = nutritionProvider ?? CompositeNutritionProvider();
+
+  /// Repository used to persist the selected food item inside the meal log.
+  final MealRepository mealRepository;
+
+  /// Provider responsible for retrieving nutritional information based on barcodes.
+  final CompositeNutritionProvider nutritionProvider;
+
+  /// Optional builder primarily used by widget tests to avoid instantiating
+  /// the platform camera widget.
+  final MobileScannerWidgetBuilder? mobileScannerBuilder;
+
+  /// Meal type that should receive the scanned ingredient.
+  final MealType mealType;
+
+  @override
+  State<ScannerScreen> createState() => _ScannerScreenState();
+}
+
+class _ScannerScreenState extends State<ScannerScreen> {
+  late final MobileScannerController _controller;
+  bool _hasPermission = true;
+  bool _isProcessing = false;
+  String? _statusMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = MobileScannerController();
+    _controller.onPermissionSet = _handlePermission;
+    _statusMessage = "Allinea il codice a barre all'interno della cornice";
+  }
+
+  @override
+  void dispose() {
+    try {
+      _controller.dispose();
+    } catch (_) {
+      // The controller invokes platform channels that are not available during
+      // widget tests. Any resulting exceptions can be safely ignored here.
+    }
+    super.dispose();
+  }
+
+  void _handlePermission(bool granted) {
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _hasPermission = granted;
+      if (!granted) {
+        _statusMessage = null;
+      } else {
+        _statusMessage ??= "Allinea il codice a barre all'interno della cornice";
+      }
+    });
+  }
+
+  void _onDetect(BarcodeCapture capture) {
+    if (_isProcessing || !_hasPermission) {
+      return;
+    }
+    unawaited(_processBarcode(capture));
+  }
+
+  Future<void> _processBarcode(BarcodeCapture capture) async {
+    final code = _extractBarcodeValue(capture);
+    if (code == null) {
+      return;
+    }
+
+    setState(() {
+      _isProcessing = true;
+      _statusMessage = null;
+    });
+
+    await _pauseScanner();
+
+    try {
+      final item = await widget.nutritionProvider.lookupByBarcode(code);
+      if (!mounted) {
+        return;
+      }
+
+      if (item == null) {
+        setState(() {
+          _isProcessing = false;
+          _statusMessage = 'Prodotto non trovato. Prova con un altro codice.';
+        });
+        await _resumeScanner();
+        return;
+      }
+
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) => ConfirmFoodScreen(
+            foodItem: item,
+            mealRepository: widget.mealRepository,
+            mealType: widget.mealType,
+            nutritionProvider: widget.nutritionProvider,
+          ),
+        ),
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      setState(() {
+        _isProcessing = false;
+        _statusMessage =
+            'Scansione completata. Puoi inquadrare un nuovo codice a barre.';
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isProcessing = false;
+        _statusMessage =
+            'Si è verificato un errore durante il recupero del prodotto.';
+      });
+    } finally {
+      await _resumeScanner();
+    }
+  }
+
+  Future<void> _pauseScanner() async {
+    try {
+      await _controller.stop();
+    } on MissingPluginException {
+      // Ignore when running in an environment without the underlying platform
+      // implementation, such as widget tests.
+    } catch (_) {
+      // Best effort pause only.
+    }
+  }
+
+  Future<void> _resumeScanner() async {
+    try {
+      await _controller.start();
+    } on MissingPluginException {
+      // Ignore for test environments without the native implementation.
+    } catch (_) {
+      // Ignore restart failures – the user can still continue scanning.
+    }
+  }
+
+  String? _extractBarcodeValue(BarcodeCapture capture) {
+    for (final barcode in capture.barcodes) {
+      final rawValue = barcode.rawValue;
+      if (rawValue != null && rawValue.isNotEmpty) {
+        return rawValue;
+      }
+      final displayValue = barcode.displayValue;
+      if (displayValue != null && displayValue.isNotEmpty) {
+        return displayValue;
+      }
+    }
+    final dynamic raw = capture.raw;
+    if (raw is String && raw.isNotEmpty) {
+      return raw;
+    }
+    return null;
+  }
+
+  Widget _buildScannerView() {
+    final builder = widget.mobileScannerBuilder;
+    if (builder != null) {
+      return builder(context, _controller, _onDetect);
+    }
+
+    return MobileScanner(
+      controller: _controller,
+      onDetect: _onDetect,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: Colors.black,
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.close, color: Colors.white),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 12),
+            child: _TorchToggle(controller: _controller),
+          ),
+        ],
+      ),
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          _buildScannerView(),
+          const _ScannerOverlay(),
+          if (_hasPermission)
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (_statusMessage != null)
+                      Text(
+                        _statusMessage!,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: Colors.white,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    if (_isProcessing)
+                      const Padding(
+                        padding: EdgeInsets.only(top: 16),
+                        child: CircularProgressIndicator(),
+                      ),
+                  ],
+                ),
+              ),
+            )
+          else
+            Center(
+              child: Container(
+                padding: const EdgeInsets.all(24),
+                decoration: BoxDecoration(
+                  color: Colors.black.withOpacity(0.8),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: const Text(
+                  'Autorizza l\'uso della fotocamera dalle impostazioni per continuare.',
+                  style: TextStyle(color: Colors.white),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TorchToggle extends StatelessWidget {
+  const _TorchToggle({required this.controller});
+
+  final MobileScannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool?>(
+      valueListenable: controller.hasTorchState,
+      builder: (context, hasTorch, child) {
+        if (hasTorch != true) {
+          return const SizedBox.shrink();
+        }
+        return ValueListenableBuilder<TorchState>(
+          valueListenable: controller.torchState,
+          builder: (context, state, child) {
+            final isOn = state == TorchState.on;
+            return IconButton(
+              onPressed: () async {
+                try {
+                  await controller.toggleTorch();
+                } on MissingPluginException {
+                  // Ignore in tests.
+                } catch (_) {
+                  // Ignore toggle failures.
+                }
+              },
+              icon: Icon(isOn ? Icons.flash_on : Icons.flash_off),
+              color: Colors.white,
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ScannerOverlay extends StatelessWidget {
+  const _ScannerOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: CustomPaint(
+        painter: _ScannerOverlayPainter(),
+        child: const SizedBox.expand(),
+      ),
+    );
+  }
+}
+
+class _ScannerOverlayPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final cutOutWidth = size.width * 0.75;
+    final cutOutHeight = cutOutWidth * 0.6;
+    final left = (size.width - cutOutWidth) / 2;
+    final top = (size.height - cutOutHeight) / 2;
+    final rect = Rect.fromLTWH(left, top, cutOutWidth, cutOutHeight);
+    final rrect = RRect.fromRectAndRadius(rect, const Radius.circular(24));
+
+    final darkPaint = Paint()..color = Colors.black54;
+    final clearPaint = Paint()..blendMode = BlendMode.clear;
+
+    canvas.saveLayer(Offset.zero & size, Paint());
+    canvas.drawRect(Offset.zero & size, darkPaint);
+    canvas.drawRRect(rrect, clearPaint);
+    canvas.restore();
+
+    final borderPaint = Paint()
+      ..color = Colors.white
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3;
+    canvas.drawRRect(rrect, borderPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}

--- a/packages/features/scanner/pubspec.yaml
+++ b/packages/features/scanner/pubspec.yaml
@@ -5,9 +5,20 @@ publish_to: 'none'
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
-  # Add package dependencies here.
+  flutter:
+    sdk: flutter
+  core_kit:
+    path: ../../core_kit
+  data_kit:
+    path: ../../data_kit
+  nutrition_kit:
+    path: ../../nutrition_kit
+  mobile_scanner: ^4.0.0
 
 dev_dependencies:
-  # Add dev dependencies here.
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.3

--- a/packages/features/scanner/test/scanner_screen_test.dart
+++ b/packages/features/scanner/test/scanner_screen_test.dart
@@ -1,0 +1,153 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:nutrition_kit/nutrition_kit.dart';
+import 'package:scanner_feature/confirm_food_screen.dart';
+import 'package:scanner_feature/scanner_screen.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const methodChannel =
+      MethodChannel('dev.steenbakker.mobile_scanner/scanner/method');
+  const eventChannel =
+      EventChannel('dev.steenbakker.mobile_scanner/scanner/event');
+
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, (MethodCall call) async {
+      if (call.method == 'start') {
+        return <String, dynamic>{
+          'numberOfCameras': 1,
+          'hasTorch': false,
+          'size': const <double>[0, 0],
+        };
+      }
+      return null;
+    });
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel, const _FakeStreamHandler());
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(methodChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockStreamHandler(eventChannel, null);
+  });
+
+  testWidgets('scanning a barcode navigates to confirmation screen',
+      (tester) async {
+    final foodItem = FoodItem.create(
+      name: 'Pane integrale',
+      nutrients: const Nutrients(
+        calories: 80,
+        protein: 4,
+        fat: 1,
+        carbohydrates: 14,
+      ),
+      servingSize: 1,
+      servingUnit: UnitType.serving,
+    );
+
+    final nutritionProvider = _TestCompositeNutritionProvider(foodItem);
+    final mealRepository = _FakeMealRepository();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ScannerScreen(
+          nutritionProvider: nutritionProvider,
+          mealRepository: mealRepository,
+          mealType: MealType.lunch,
+          mobileScannerBuilder: (
+            context,
+            controller,
+            onDetect,
+          ) {
+            return Center(
+              child: ElevatedButton(
+                key: const Key('fake-scanner'),
+                onPressed: () {
+                  onDetect(
+                    BarcodeCapture(
+                      barcodes: const <Barcode>[
+                        Barcode(rawValue: '0123456789012'),
+                      ],
+                    ),
+                  );
+                },
+                child: const Text('Scan'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const Key('fake-scanner')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ConfirmFoodScreen), findsOneWidget);
+    expect(find.text('Pane integrale'), findsOneWidget);
+
+    await tester.tap(find.text('Aggiungi al pasto'));
+    await tester.pumpAndSettle();
+
+    expect(mealRepository.addedMealType, MealType.lunch);
+    expect(mealRepository.addedItem, equals(foodItem));
+    expect(mealRepository.addedQuantity, greaterThan(0));
+    expect(mealRepository.addedUnit, UnitType.serving);
+  });
+}
+
+class _FakeMealRepository implements MealRepository {
+  MealType? addedMealType;
+  FoodItem? addedItem;
+  double? addedQuantity;
+  UnitType? addedUnit;
+
+  @override
+  Future<void> addIngredient({
+    required MealType mealType,
+    required FoodItem item,
+    required double quantity,
+    required UnitType unit,
+  }) async {
+    addedMealType = mealType;
+    addedItem = item;
+    addedQuantity = quantity;
+    addedUnit = unit;
+  }
+}
+
+class _TestCompositeNutritionProvider extends CompositeNutritionProvider {
+  _TestCompositeNutritionProvider(this._result)
+      : super(
+          providers: const <NutritionProvider>[],
+          manualCatalog: const <String, FoodItem>{},
+        );
+
+  final FoodItem _result;
+
+  @override
+  Future<FoodItem?> lookupByBarcode(String barcode) async => _result;
+
+  @override
+  Future<List<FoodItem>> searchFoods(String query) async => <FoodItem>[];
+
+  @override
+  Future<Nutrients?> nutrientsFor(FoodItem item) async => item.nutrients;
+}
+
+class _FakeStreamHandler extends StreamHandler<dynamic> {
+  const _FakeStreamHandler();
+
+  @override
+  Future<void> onCancel(Object? arguments) async {}
+
+  @override
+  Future<void> onListen(Object? arguments, EventSink<dynamic> sink) async {}
+}


### PR DESCRIPTION
## Summary
- add a full screen scanner that drives barcode lookups and routes to confirmation
- provide a confirmation experience with quantity controls and data kit integration
- cover the scanner flow with a widget test using a simulated barcode

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cfcc915698832f937ff17e65b4e413