### PR TITLE
Implement meals feature UI and repository

### DIFF
--- a/packages/features/meals/lib/meals_feature.dart
+++ b/packages/features/meals/lib/meals_feature.dart
@@ -1,0 +1,6 @@
+library meals_feature;
+
+export 'src/add_meal_flow.dart';
+export 'src/daily_diary_screen.dart';
+export 'src/meals_repository.dart';
+export 'src/quantity_stepper.dart';

--- a/packages/features/meals/lib/src/add_meal_flow.dart
+++ b/packages/features/meals/lib/src/add_meal_flow.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+
+/// Guides the user through the available ways of adding a meal entry.
+class AddMealFlow extends StatelessWidget {
+  const AddMealFlow({
+    super.key,
+    required this.onScan,
+    required this.onSearch,
+    required this.onRecipes,
+    required this.onQuickAdd,
+    this.title,
+    this.subtitle,
+    this.padding = const EdgeInsets.all(24),
+  });
+
+  /// Callback invoked when the user chooses the barcode scanning option.
+  final VoidCallback onScan;
+
+  /// Callback invoked when the user chooses to search for food items.
+  final VoidCallback onSearch;
+
+  /// Callback invoked when the user wants to browse saved recipes.
+  final VoidCallback onRecipes;
+
+  /// Callback invoked when the user wants to log a quick entry.
+  final VoidCallback onQuickAdd;
+
+  /// Optional title displayed above the available actions.
+  final String? title;
+
+  /// Optional subtitle providing additional context.
+  final String? subtitle;
+
+  /// Padding applied around the action list.
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final headerWidgets = <Widget>[];
+
+    if (title != null) {
+      headerWidgets.add(
+        Text(
+          title!,
+          style: theme.textTheme.headlineSmall,
+        ),
+      );
+    }
+
+    if (subtitle != null) {
+      headerWidgets.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Text(
+            subtitle!,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      );
+    }
+
+    final options = <_FlowOption>[
+      _FlowOption(
+        label: 'Scansiona',
+        description: 'Inquadra il codice a barre di un prodotto.',
+        icon: Icons.qr_code_scanner,
+        onTap: onScan,
+      ),
+      _FlowOption(
+        label: 'Cerca',
+        description: 'Trova un alimento nel catalogo.',
+        icon: Icons.search,
+        onTap: onSearch,
+      ),
+      _FlowOption(
+        label: 'Ricette',
+        description: 'Aggiungi una delle tue ricette salvate.',
+        icon: Icons.book_outlined,
+        onTap: onRecipes,
+      ),
+      _FlowOption(
+        label: 'Rapidi',
+        description: 'Registra velocemente calorie o note.',
+        icon: Icons.bolt_outlined,
+        onTap: onQuickAdd,
+      ),
+    ];
+
+    return ListView(
+      padding: padding,
+      shrinkWrap: true,
+      children: [
+        if (headerWidgets.isNotEmpty) ...[
+          ...headerWidgets,
+          const SizedBox(height: 24),
+        ],
+        ...options.map(
+          (option) => Padding(
+            padding: const EdgeInsets.only(bottom: 16),
+            child: _AddMealOption(option: option),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _FlowOption {
+  const _FlowOption({
+    required this.label,
+    required this.description,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String label;
+  final String description;
+  final IconData icon;
+  final VoidCallback onTap;
+}
+
+class _AddMealOption extends StatelessWidget {
+  const _AddMealOption({required this.option});
+
+  final _FlowOption option;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: option.onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Row(
+            children: [
+              CircleAvatar(
+                backgroundColor: theme.colorScheme.primary.withOpacity(0.1),
+                foregroundColor: theme.colorScheme.primary,
+                child: Icon(option.icon),
+              ),
+              const SizedBox(width: 20),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      option.label,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      option.description,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.chevron_right),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/features/meals/lib/src/daily_diary_screen.dart
+++ b/packages/features/meals/lib/src/daily_diary_screen.dart
@@ -1,0 +1,275 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+
+import 'meals_repository.dart';
+
+/// Displays the logged meals and macro nutrients for a single day.
+class DailyDiaryScreen extends StatefulWidget {
+  const DailyDiaryScreen({
+    super.key,
+    required this.repository,
+    required DateTime date,
+  }) : date = DateTime(date.year, date.month, date.day);
+
+  /// Repository providing the diary data.
+  final MealsRepository repository;
+
+  /// Day rendered by this screen. The time component is ignored.
+  final DateTime date;
+
+  @override
+  State<DailyDiaryScreen> createState() => _DailyDiaryScreenState();
+}
+
+class _DailyDiaryScreenState extends State<DailyDiaryScreen> {
+  late final Stream<DailyDiary> _diaryStream;
+
+  @override
+  void initState() {
+    super.initState();
+    _diaryStream = widget.repository.watchDiary(widget.date);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final formattedDate = _formatDate(widget.date);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Diario • $formattedDate'),
+      ),
+      body: StreamBuilder<DailyDiary>(
+        stream: _diaryStream,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final diary = snapshot.data!;
+          final theme = Theme.of(context);
+
+          return ListView(
+            padding: const EdgeInsets.all(24),
+            children: [
+              Text(
+                'Riepilogo macro',
+                style: theme.textTheme.titleLarge,
+              ),
+              const SizedBox(height: 16),
+              _MacroSummary(summary: diary.macroSummary),
+              const SizedBox(height: 32),
+              Text(
+                'Pasti registrati',
+                style: theme.textTheme.titleLarge,
+              ),
+              const SizedBox(height: 12),
+              if (diary.meals.isEmpty)
+                Text(
+                  'Nessun pasto registrato per questo giorno.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                )
+              else
+                ...diary.meals.map((meal) => _MealTile(meal: meal)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final day = date.day.toString().padLeft(2, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final year = date.year.toString();
+    return '$day/$month/$year';
+  }
+}
+
+class _MacroSummary extends StatelessWidget {
+  const _MacroSummary({required this.summary});
+
+  final DailyMacroSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final macros = <_MacroData>[
+      _MacroData(
+        label: 'Calorie',
+        value: summary.consumed.calories,
+        goal: summary.goal.calories,
+        unit: 'kcal',
+      ),
+      _MacroData(
+        label: 'Proteine',
+        value: summary.consumed.protein,
+        goal: summary.goal.protein,
+        unit: 'g',
+      ),
+      _MacroData(
+        label: 'Carboidrati',
+        value: summary.consumed.carbohydrates,
+        goal: summary.goal.carbohydrates,
+        unit: 'g',
+      ),
+      _MacroData(
+        label: 'Grassi',
+        value: summary.consumed.fat,
+        goal: summary.goal.fat,
+        unit: 'g',
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth > 600;
+        final itemWidth = isWide ? (constraints.maxWidth - 16) / 2 : constraints.maxWidth;
+        return Wrap(
+          spacing: 16,
+          runSpacing: 16,
+          children: macros
+              .map(
+                (macro) => SizedBox(
+                  width: itemWidth,
+                  child: _MacroCard(macro: macro),
+                ),
+              )
+              .toList(),
+        );
+      },
+    );
+  }
+}
+
+class _MacroCard extends StatelessWidget {
+  const _MacroCard({required this.macro});
+
+  final _MacroData macro;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            NutrientRing(
+              value: macro.value,
+              goal: macro.goal,
+              size: 120,
+              strokeWidth: 10,
+              center: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '${macro.percent}%',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    macro.label,
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              macro.formattedValue,
+              style: theme.textTheme.titleMedium,
+            ),
+            Text(
+              'Obiettivo ${macro.formattedGoal}',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MacroData {
+  _MacroData({
+    required this.label,
+    required this.value,
+    required this.goal,
+    required this.unit,
+  });
+
+  final String label;
+  final double value;
+  final double goal;
+  final String unit;
+
+  int get percent {
+    if (goal <= 0) {
+      return 0;
+    }
+    final ratio = (value / goal).clamp(0.0, 1.0);
+    return (ratio * 100).round();
+  }
+
+  String get formattedValue => '${_formatNumber(value)} $unit';
+
+  String get formattedGoal => '${_formatNumber(goal)} $unit';
+
+  String _formatNumber(double value) {
+    if (value == 0) {
+      return '0';
+    }
+    if (value >= 100) {
+      return value.toStringAsFixed(0).replaceAll('.', ',');
+    }
+    return value.toStringAsFixed(1).replaceAll('.', ',');
+  }
+}
+
+class _MealTile extends StatelessWidget {
+  const _MealTile({required this.meal});
+
+  final MealEntry meal;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final time = TimeOfDay.fromDateTime(meal.consumedAt);
+    final timeLabel = time.format(context);
+    final ingredients = meal.ingredients;
+    final subtitle = ingredients.isEmpty
+        ? 'Nessun alimento registrato'
+        : ingredients.map((ingredient) => ingredient.item.name).join(', ');
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: ListTile(
+        title: Text(
+          '${_mealTypeLabel(meal.mealType)} • $timeLabel',
+          style: theme.textTheme.titleMedium,
+        ),
+        subtitle: Text(subtitle),
+      ),
+    );
+  }
+
+  String _mealTypeLabel(MealType type) {
+    switch (type) {
+      case MealType.breakfast:
+        return 'Colazione';
+      case MealType.lunch:
+        return 'Pranzo';
+      case MealType.dinner:
+        return 'Cena';
+      case MealType.snack:
+        return 'Spuntino';
+    }
+  }
+}

--- a/packages/features/meals/lib/src/meals_repository.dart
+++ b/packages/features/meals/lib/src/meals_repository.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+
+import 'package:core_kit/core_kit.dart';
+import 'package:data_kit/data_kit.dart';
+import 'package:flutter/foundation.dart';
+import 'package:nutrition_kit/nutrition_kit.dart';
+
+/// Aggregated information about the logged meals for a specific day.
+class DailyDiary {
+  const DailyDiary({
+    required this.date,
+    required this.meals,
+    required this.macroSummary,
+  });
+
+  /// Date represented by this snapshot (time stripped).
+  final DateTime date;
+
+  /// Meals logged for the date ordered chronologically.
+  final List<MealEntry> meals;
+
+  /// Total macro nutrients consumed during the day.
+  final DailyMacroSummary macroSummary;
+}
+
+/// Provides macro totals and goal information for a day.
+class DailyMacroSummary {
+  const DailyMacroSummary({
+    required this.consumed,
+    required this.goal,
+  });
+
+  /// Nutrients consumed for the day.
+  final Nutrients consumed;
+
+  /// Target nutrients used for progress visualisation.
+  final Nutrients goal;
+}
+
+/// Repository that coordinates persistence of [MealEntry] records using Drift.
+class MealsRepository {
+  MealsRepository(
+    this._mealEntryDao, {
+    Nutrients? dailyMacroGoal,
+  }) : _dailyGoal = dailyMacroGoal ??
+            const Nutrients(
+              calories: 2000,
+              protein: 90,
+              fat: 70,
+              carbohydrates: 250,
+            ) {
+    // Load the initial cache asynchronously.
+    unawaited(_refresh());
+  }
+
+  final MealEntryDao _mealEntryDao;
+  final Nutrients _dailyGoal;
+
+  final _entriesController = StreamController<List<MealEntry>>.broadcast();
+  List<MealEntry> _cache = const <MealEntry>[];
+  bool _disposed = false;
+
+  /// Stream emitting diary snapshots for the given [day].
+  Stream<DailyDiary> watchDiary(DateTime day) {
+    final normalized = _normalize(day);
+    return _entriesStream().map(
+      (entries) => _buildDiarySnapshot(entries, normalized),
+    );
+  }
+
+  /// Returns meals logged for [day] without subscribing to updates.
+  Future<List<MealEntry>> loadMealsForDay(DateTime day) async {
+    final normalized = _normalize(day);
+    final entries = await _mealEntryDao.getMealEntries();
+    return _filterEntriesForDay(entries, normalized);
+  }
+
+  /// Persists [entry] replacing any existing record with the same id.
+  Future<void> upsertMeal(MealEntry entry) async {
+    await _mealEntryDao.upsertMealEntry(entry);
+    await _refresh();
+  }
+
+  /// Deletes the meal entry identified by [id].
+  Future<void> deleteMeal(String id) async {
+    await _mealEntryDao.deleteMealEntry(id);
+    await _refresh();
+  }
+
+  /// Forces a refresh of the cached entries. Exposed for testability.
+  @visibleForTesting
+  Future<void> refresh() => _refresh();
+
+  /// Releases resources held by the repository.
+  Future<void> dispose() async {
+    _disposed = true;
+    await _entriesController.close();
+  }
+
+  Stream<List<MealEntry>> _entriesStream() {
+    return Stream<List<MealEntry>>.multi((controller) {
+      if (_disposed) {
+        controller.close();
+        return;
+      }
+
+      controller.add(_cache);
+      final subscription = _entriesController.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller.onCancel = subscription.cancel;
+    }, isBroadcast: true);
+  }
+
+  Future<void> _refresh() async {
+    final entries = await _mealEntryDao.getMealEntries();
+    if (_disposed) {
+      return;
+    }
+    _cache = List<MealEntry>.unmodifiable(entries);
+    if (!_entriesController.isClosed) {
+      _entriesController.add(_cache);
+    }
+  }
+
+  DailyDiary _buildDiarySnapshot(List<MealEntry> entries, DateTime day) {
+    final meals = _filterEntriesForDay(entries, day);
+    meals.sort((a, b) => a.consumedAt.compareTo(b.consumedAt));
+    final macroSummary = DailyMacroSummary(
+      consumed: _calculateNutrients(meals),
+      goal: _dailyGoal,
+    );
+    return DailyDiary(
+      date: day,
+      meals: List<MealEntry>.unmodifiable(meals),
+      macroSummary: macroSummary,
+    );
+  }
+
+  List<MealEntry> _filterEntriesForDay(List<MealEntry> entries, DateTime day) {
+    return entries
+        .where((entry) => _isSameDay(entry.consumedAt, day))
+        .toList(growable: true);
+  }
+
+  Nutrients _calculateNutrients(List<MealEntry> entries) {
+    var total = const Nutrients();
+    for (final entry in entries) {
+      for (final ingredient in entry.ingredients) {
+        final nutrients = computeNutrients(
+          ingredient.item,
+          ingredient.quantity,
+          ingredient.unit,
+        );
+        total = _addNutrients(total, nutrients);
+      }
+    }
+    return total;
+  }
+
+  Nutrients _addNutrients(Nutrients base, Nutrients addition) {
+    return Nutrients(
+      calories: base.calories + addition.calories,
+      protein: base.protein + addition.protein,
+      fat: base.fat + addition.fat,
+      carbohydrates: base.carbohydrates + addition.carbohydrates,
+      fiber: base.fiber + addition.fiber,
+      sugar: base.sugar + addition.sugar,
+      sodium: base.sodium + addition.sodium,
+    );
+  }
+
+  DateTime _normalize(DateTime value) => DateTime(value.year, value.month, value.day);
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+}

--- a/packages/features/meals/lib/src/quantity_stepper.dart
+++ b/packages/features/meals/lib/src/quantity_stepper.dart
@@ -1,0 +1,182 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// A numeric stepper that allows changing a quantity with undo support.
+class QuantityStepper extends StatefulWidget {
+  const QuantityStepper({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.step = 1.0,
+    this.min = 0.0,
+    this.max,
+    this.label,
+    this.unitLabel,
+    this.precision = 1,
+    this.snackBarDuration = const Duration(seconds: 3),
+    this.undoLabel = 'Annulla',
+  }) : assert(precision >= 0, 'Precision must be zero or positive.');
+
+  /// Current value rendered by the stepper.
+  final double value;
+
+  /// Callback triggered whenever the value changes.
+  final ValueChanged<double> onChanged;
+
+  /// Amount added or subtracted on each step.
+  final double step;
+
+  /// Lower bound for the value.
+  final double min;
+
+  /// Optional maximum allowed value.
+  final double? max;
+
+  /// Optional label displayed above the control.
+  final String? label;
+
+  /// Optional unit appended to the formatted quantity.
+  final String? unitLabel;
+
+  /// Number of decimal places used when rounding values.
+  final int precision;
+
+  /// Duration for which the undo snackbar remains visible.
+  final Duration snackBarDuration;
+
+  /// Label used for the snackbar undo action.
+  final String undoLabel;
+
+  @override
+  State<QuantityStepper> createState() => _QuantityStepperState();
+}
+
+class _QuantityStepperState extends State<QuantityStepper> {
+  void _changeBy(double delta) {
+    final previous = widget.value;
+    var updated = previous + delta;
+    updated = _clamp(updated);
+    updated = _round(updated);
+
+    if ((updated - previous).abs() < 1e-6) {
+      return;
+    }
+
+    widget.onChanged(updated);
+    _showUndoSnackBar(previous, updated);
+  }
+
+  double _clamp(double value) {
+    var result = value;
+    if (result < widget.min) {
+      result = widget.min;
+    }
+    final max = widget.max;
+    if (max != null && result > max) {
+      result = max;
+    }
+    return result;
+  }
+
+  double _round(double value) {
+    if (widget.precision <= 0) {
+      return value.roundToDouble();
+    }
+    final factor = math.pow(10, widget.precision).toDouble();
+    return (value * factor).round() / factor;
+  }
+
+  bool get _canDecrement => widget.value - widget.min > 1e-6;
+
+  bool get _canIncrement {
+    final max = widget.max;
+    if (max == null) {
+      return true;
+    }
+    return max - widget.value > 1e-6;
+  }
+
+  void _showUndoSnackBar(double previous, double next) {
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) {
+      return;
+    }
+
+    messenger.hideCurrentSnackBar();
+    final formatted = _formatValue(next);
+    final unitSuffix = widget.unitLabel != null
+        ? ' ${widget.unitLabel!.toLowerCase()}'
+        : '';
+    messenger.showSnackBar(
+      SnackBar(
+        duration: widget.snackBarDuration,
+        content: Text('Quantità aggiornata a $formatted$unitSuffix'),
+        action: SnackBarAction(
+          label: widget.undoLabel,
+          onPressed: () {
+            widget.onChanged(previous);
+          },
+        ),
+      ),
+    );
+  }
+
+  String _formatValue(double value) {
+    if (widget.precision == 0 || value % 1 == 0) {
+      return value.toStringAsFixed(0).replaceAll('.', ',');
+    }
+    return value
+        .toStringAsFixed(widget.precision)
+        .replaceAll('.', ',');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final formatted = _formatValue(widget.value);
+    final unit = widget.unitLabel;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.label != null)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              widget.label!,
+              style: theme.textTheme.titleMedium,
+            ),
+          ),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            color: theme.colorScheme.surfaceVariant,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.remove),
+                onPressed: _canDecrement ? () => _changeBy(-widget.step) : null,
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Text(
+                  unit == null ? formatted : '$formatted $unit',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: _canIncrement ? () => _changeBy(widget.step) : null,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/features/meals/pubspec.yaml
+++ b/packages/features/meals/pubspec.yaml
@@ -5,9 +5,19 @@ publish_to: 'none'
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
-  # Add package dependencies here.
+  flutter:
+    sdk: flutter
+  core_kit:
+    path: ../../core_kit
+  data_kit:
+    path: ../../data_kit
+  nutrition_kit:
+    path: ../../nutrition_kit
 
 dev_dependencies:
-  # Add dev dependencies here.
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.3

--- a/packages/features/meals/test/add_meal_flow_test.dart
+++ b/packages/features/meals/test/add_meal_flow_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meals_feature/meals_feature.dart';
+
+void main() {
+  testWidgets('renders the four add meal options and triggers callbacks',
+      (tester) async {
+    var selection = '';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AddMealFlow(
+            onScan: () => selection = 'scan',
+            onSearch: () => selection = 'search',
+            onRecipes: () => selection = 'recipes',
+            onQuickAdd: () => selection = 'quick',
+            title: 'Aggiungi pasto',
+            subtitle: 'Scegli come vuoi registrare il tuo pasto.',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Scansiona'), findsOneWidget);
+    expect(find.text('Cerca'), findsOneWidget);
+    expect(find.text('Ricette'), findsOneWidget);
+    expect(find.text('Rapidi'), findsOneWidget);
+
+    await tester.tap(find.text('Scansiona'));
+    await tester.pumpAndSettle();
+    expect(selection, 'scan');
+
+    await tester.tap(find.text('Cerca'));
+    await tester.pumpAndSettle();
+    expect(selection, 'search');
+
+    await tester.tap(find.text('Ricette'));
+    await tester.pumpAndSettle();
+    expect(selection, 'recipes');
+
+    await tester.tap(find.text('Rapidi'));
+    await tester.pumpAndSettle();
+    expect(selection, 'quick');
+  });
+}

--- a/packages/features/meals/test/daily_diary_screen_test.dart
+++ b/packages/features/meals/test/daily_diary_screen_test.dart
@@ -1,0 +1,83 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:data_kit/data_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meals_feature/meals_feature.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockMealEntryDao extends Mock implements MealEntryDao {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(
+      MealEntry.create(
+        mealType: MealType.breakfast,
+        consumedAt: DateTime.utc(2024, 1, 1),
+      ),
+    );
+  });
+
+  testWidgets('shows macro summary and meals for the selected day', (tester) async {
+    final dao = _MockMealEntryDao();
+    final date = DateTime(2024, 5, 10);
+
+    final food = FoodItem.create(
+      name: 'Pasta integrale',
+      nutrients: const Nutrients(
+        calories: 200,
+        protein: 10,
+        fat: 5,
+        carbohydrates: 30,
+      ),
+      servingSize: 100,
+      servingUnit: UnitType.gram,
+    );
+
+    final ingredient = Ingredient.create(
+      item: food,
+      quantity: 150,
+      unit: UnitType.gram,
+    );
+
+    final meal = MealEntry.create(
+      mealType: MealType.lunch,
+      consumedAt: DateTime(2024, 5, 10, 13),
+      ingredients: <Ingredient>[ingredient],
+    );
+
+    when(() => dao.getMealEntries()).thenAnswer((_) async => <MealEntry>[meal]);
+    when(() => dao.upsertMealEntry(any())).thenAnswer((_) async {});
+    when(() => dao.deleteMealEntry(any())).thenAnswer((_) async => 1);
+
+    final repository = MealsRepository(
+      dao,
+      dailyMacroGoal: const Nutrients(
+        calories: 600,
+        protein: 40,
+        fat: 20,
+        carbohydrates: 90,
+      ),
+    );
+    addTearDown(repository.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DailyDiaryScreen(repository: repository, date: date),
+      ),
+    );
+
+    // Allow asynchronous loading from the repository.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Riepilogo macro'), findsOneWidget);
+    expect(find.byType(NutrientRing), findsWidgets);
+    expect(find.text('300 kcal'), findsOneWidget);
+    expect(find.text('Obiettivo 600 kcal'), findsOneWidget);
+    expect(find.text('15,0 g'), findsWidgets);
+    expect(find.textContaining('Pranzo'), findsOneWidget);
+    expect(find.text('Pasta integrale'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add the AddMealFlow widget with scan, search, recipe and quick entry actions
- implement a QuantityStepper with undo feedback and a MealsRepository backed by data_kit
- create the DailyDiaryScreen with macro nutrient rings and add widget tests for the new UI

## Testing
- flutter test packages/features/meals *(fails: flutter command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfeff734e4832fbaaad46259633825