### PR TITLE
feat(recipes): add recipe detail screen with servings scaling

### DIFF
--- a/packages/features/recipes/lib/recipes_feature.dart
+++ b/packages/features/recipes/lib/recipes_feature.dart
@@ -1,0 +1,4 @@
+library recipes_feature;
+
+export 'src/recipe_detail_screen.dart';
+export 'src/seed_recipes_repository.dart';

--- a/packages/features/recipes/lib/src/recipe_detail_screen.dart
+++ b/packages/features/recipes/lib/src/recipe_detail_screen.dart
@@ -1,0 +1,361 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:meals_feature/meals_feature.dart';
+import 'package:nutrition_kit/nutrition_kit.dart';
+
+/// Displays the details of a [Recipe] allowing the user to scale servings
+/// before logging it as a meal entry.
+class RecipeDetailScreen extends StatefulWidget {
+  const RecipeDetailScreen({
+    super.key,
+    required this.recipe,
+    required this.mealsRepository,
+    required this.mealType,
+    required this.consumedAt,
+  });
+
+  /// Recipe displayed in the screen.
+  final Recipe recipe;
+
+  /// Repository used to persist the generated [MealEntry].
+  final MealsRepository mealsRepository;
+
+  /// Meal slot where the recipe should be logged.
+  final MealType mealType;
+
+  /// Timestamp associated with the logged meal.
+  final DateTime consumedAt;
+
+  @override
+  State<RecipeDetailScreen> createState() => _RecipeDetailScreenState();
+}
+
+class _RecipeDetailScreenState extends State<RecipeDetailScreen> {
+  late final double _baseServings;
+  late double _servings;
+  late List<Ingredient> _scaledIngredients;
+  late Nutrients _nutrients;
+
+  @override
+  void initState() {
+    super.initState();
+    _baseServings = widget.recipe.servingSize <= 0
+        ? 1
+        : widget.recipe.servingSize;
+    _servings = _baseServings;
+    _recalculate();
+  }
+
+  void _recalculate() {
+    final factor = _baseServings == 0 ? 0 : _servings / _baseServings;
+    _scaledIngredients = widget.recipe.ingredients
+        .map(
+          (ingredient) => ingredient.copyWith(
+            quantity: ingredient.quantity * factor,
+          ),
+        )
+        .toList(growable: false);
+
+    _nutrients = _calculateNutrients(_scaledIngredients);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final description = widget.recipe.description;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.recipe.title),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          if (description.isNotEmpty) ...[
+            Text(
+              description,
+              style: theme.textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 16),
+          ],
+          QuantityStepper(
+            value: _servings,
+            onChanged: (value) {
+              setState(() {
+                _servings = value;
+                _recalculate();
+              });
+            },
+            label: 'Porzioni',
+            unitLabel: 'porz.',
+            step: 0.5,
+            min: 0.5,
+            precision: 1,
+          ),
+          const SizedBox(height: 24),
+          _NutrientSummary(nutrients: _nutrients),
+          const SizedBox(height: 24),
+          Text(
+            'Ingredienti',
+            style: theme.textTheme.titleLarge,
+          ),
+          const SizedBox(height: 12),
+          if (_scaledIngredients.isEmpty)
+            Text(
+              'Nessun ingrediente disponibile per questa ricetta.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          else
+            ..._scaledIngredients.map(_IngredientTile.new),
+          if (widget.recipe.instructions.isNotEmpty) ...[
+            const SizedBox(height: 32),
+            Text(
+              'Istruzioni',
+              style: theme.textTheme.titleLarge,
+            ),
+            const SizedBox(height: 12),
+            ...List<Widget>.generate(
+              widget.recipe.instructions.length,
+              (index) => Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('${index + 1}. ', style: theme.textTheme.titleMedium),
+                    Expanded(
+                      child: Text(
+                        widget.recipe.instructions[index],
+                        style: theme.textTheme.bodyLarge,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+          const SizedBox(height: 32),
+          PrimaryButton(
+            label: 'Aggiungi al pasto',
+            icon: const Icon(Icons.restaurant),
+            expanded: true,
+            onPressed: _scaledIngredients.isEmpty ? null : _addToMeal,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Nutrients _calculateNutrients(List<Ingredient> ingredients) {
+    var total = const Nutrients();
+    for (final ingredient in ingredients) {
+      final nutrients = computeNutrients(
+        ingredient.item,
+        ingredient.quantity,
+        ingredient.unit,
+      );
+      total = Nutrients(
+        calories: total.calories + nutrients.calories,
+        protein: total.protein + nutrients.protein,
+        fat: total.fat + nutrients.fat,
+        carbohydrates: total.carbohydrates + nutrients.carbohydrates,
+        fiber: total.fiber + nutrients.fiber,
+        sugar: total.sugar + nutrients.sugar,
+        sodium: total.sodium + nutrients.sodium,
+      );
+    }
+    return total;
+  }
+
+  Future<void> _addToMeal() async {
+    final entry = MealEntry.create(
+      mealType: widget.mealType,
+      consumedAt: widget.consumedAt,
+      ingredients: _scaledIngredients,
+      recipeId: widget.recipe.id,
+      servings: _servings,
+    );
+    await widget.mealsRepository.upsertMeal(entry);
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Ricetta aggiunta al diario.'),
+      ),
+    );
+  }
+}
+
+class _IngredientTile extends StatelessWidget {
+  const _IngredientTile(this.ingredient);
+
+  final Ingredient ingredient;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final unit = _formatUnit(ingredient.unit);
+    final quantity = _formatQuantity(ingredient.quantity);
+    final details = <String>[
+      unit == null ? quantity : '$quantity $unit',
+    ];
+    final preparation = ingredient.preparation;
+    if (preparation != null && preparation.isNotEmpty) {
+      details.add(preparation);
+    }
+
+    return Card(
+      elevation: 0,
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        title: Text(
+          ingredient.item.name,
+          style: theme.textTheme.titleMedium,
+        ),
+        subtitle: Text(
+          details.where((segment) => segment.isNotEmpty).join(' • '),
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+
+  String? _formatUnit(UnitType unit) {
+    switch (unit) {
+      case UnitType.gram:
+        return 'g';
+      case UnitType.milliliter:
+        return 'ml';
+      case UnitType.ounce:
+        return 'oz';
+      case UnitType.pound:
+        return 'lb';
+      case UnitType.piece:
+        return 'pz';
+      case UnitType.cup:
+        return 'cup';
+      case UnitType.tablespoon:
+        return 'cucchiaio';
+      case UnitType.teaspoon:
+        return 'cucchiaino';
+      case UnitType.serving:
+        return 'porz.';
+    }
+  }
+
+  String _formatQuantity(double value) {
+    if (value % 1 == 0) {
+      return value.toStringAsFixed(0);
+    }
+    return value.toStringAsFixed(1);
+  }
+}
+
+class _NutrientSummary extends StatelessWidget {
+  const _NutrientSummary({required this.nutrients});
+
+  final Nutrients nutrients;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final items = <_NutrientData>[
+      _NutrientData(
+        label: 'Calorie',
+        value: nutrients.calories,
+        unit: 'kcal',
+        valueKey: const Key('nutrient_calories_value'),
+      ),
+      _NutrientData(
+        label: 'Proteine',
+        value: nutrients.protein,
+        unit: 'g',
+        valueKey: const Key('nutrient_protein_value'),
+      ),
+      _NutrientData(
+        label: 'Carboidrati',
+        value: nutrients.carbohydrates,
+        unit: 'g',
+        valueKey: const Key('nutrient_carbs_value'),
+      ),
+      _NutrientData(
+        label: 'Grassi',
+        value: nutrients.fat,
+        unit: 'g',
+        valueKey: const Key('nutrient_fat_value'),
+      ),
+    ];
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Valori nutrizionali',
+              style: theme.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            ...items.map((item) => _NutrientRow(item: item)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NutrientRow extends StatelessWidget {
+  const _NutrientRow({required this.item});
+
+  final _NutrientData item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            item.label,
+            style: theme.textTheme.bodyLarge,
+          ),
+          Text(
+            '${item.formattedValue} ${item.unit}',
+            key: item.valueKey,
+            style: theme.textTheme.titleMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NutrientData {
+  _NutrientData({
+    required this.label,
+    required this.value,
+    required this.unit,
+    required this.valueKey,
+  });
+
+  final String label;
+  final double value;
+  final String unit;
+  final Key valueKey;
+
+  String get formattedValue {
+    if (value % 1 == 0) {
+      return value.toStringAsFixed(0);
+    }
+    return value.toStringAsFixed(1);
+  }
+}

--- a/packages/features/recipes/lib/src/seed_recipes_repository.dart
+++ b/packages/features/recipes/lib/src/seed_recipes_repository.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:core_kit/core_kit.dart';
+import 'package:nutrition_kit/nutrition_kit.dart';
+import 'package:path/path.dart' as p;
+
+/// Loads the bundled recipe catalog used by the demo application.
+class SeedRecipesRepository {
+  SeedRecipesRepository._() {
+    _loadSeedData();
+  }
+
+  /// Singleton accessor to keep disk reads minimal during tests.
+  static final SeedRecipesRepository instance = SeedRecipesRepository._();
+
+  late final Map<String, Recipe> _recipesById;
+
+  /// All recipes available in the seed catalog.
+  List<Recipe> get recipes => _recipesById.values.toList(growable: false);
+
+  /// Returns the recipe identified by [id] if present in the catalog.
+  Recipe? recipeById(String id) => _recipesById[id];
+
+  /// Performs a very small search over the seed catalog using [query].
+  List<Recipe> search(String query) {
+    if (query.trim().isEmpty) {
+      return recipes;
+    }
+    final lower = query.toLowerCase();
+    return recipes
+        .where((recipe) =>
+            recipe.title.toLowerCase().contains(lower) ||
+            recipe.tags.any((tag) => tag.toLowerCase().contains(lower)))
+        .toList(growable: false);
+  }
+
+  void _loadSeedData() {
+    final file = _resolveSeedFile();
+    if (file == null) {
+      throw StateError('Unable to locate recipes seed file.');
+    }
+    final jsonData =
+        jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    final recipesJson = jsonData['recipes'] as List<dynamic>? ?? <dynamic>[];
+
+    _recipesById = <String, Recipe>{};
+    for (final dynamic entry in recipesJson) {
+      final recipeJson = entry as Map<String, dynamic>;
+      final recipe = _parseRecipe(recipeJson);
+      _recipesById[recipe.id] = recipe;
+    }
+  }
+
+  File? _resolveSeedFile() {
+    final candidates = <String>[
+      p.join('packages', 'features', 'recipes', 'seed', 'recipes.json'),
+      p.join('..', 'features', 'recipes', 'seed', 'recipes.json'),
+      p.join('seed', 'recipes.json'),
+      p.join('recipes', 'seed', 'recipes.json'),
+    ];
+    for (final candidate in candidates) {
+      final file = File(candidate);
+      if (file.existsSync()) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  Recipe _parseRecipe(Map<String, dynamic> json) {
+    final nutrientsJson =
+        json['nutrients'] as Map<String, dynamic>? ?? <String, dynamic>{};
+    final ingredientsJson =
+        json['ingredients'] as List<dynamic>? ?? <dynamic>[];
+    final instructions =
+        _stringList(json['instructions']);
+    final tags = _stringList(json['tags']);
+
+    return Recipe(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      description: json['description'] as String? ?? '',
+      nutrients: Nutrients(
+        calories: _toDouble(nutrientsJson['calories']),
+        protein: _toDouble(nutrientsJson['protein']),
+        fat: _toDouble(nutrientsJson['fat']),
+        carbohydrates: _toDouble(nutrientsJson['carbohydrates']),
+        fiber: _toDouble(nutrientsJson['fiber']),
+        sugar: _toDouble(nutrientsJson['sugar']),
+        sodium: _toDouble(nutrientsJson['sodium']),
+      ),
+      servingSize: _toDouble(json['servingSize']),
+      servingUnit: UnitType.values.byName(json['servingUnit'] as String),
+      ingredients: ingredientsJson
+          .map((dynamic ingredient) =>
+              _parseIngredient(ingredient as Map<String, dynamic>, json['id']))
+          .toList(growable: false),
+      instructions: instructions,
+      tags: tags,
+      prepTimeMinutes: _toInt(json['prepTimeMinutes']),
+      cookTimeMinutes: _toInt(json['cookTimeMinutes']),
+      imageUrl: json['imageUrl'] as String?,
+      sourceUrl: json['sourceUrl'] as String?,
+    );
+  }
+
+  Ingredient _parseIngredient(
+    Map<String, dynamic> json,
+    String recipeId,
+  ) {
+    final itemId = json['itemId'] as String?;
+    final itemJson = json['item'] as Map<String, dynamic>?;
+    final foodItem = _resolveFoodItem(itemId, itemJson);
+
+    if (foodItem == null) {
+      throw StateError(
+        'Unable to resolve ingredient food item for recipe $recipeId.',
+      );
+    }
+
+    return Ingredient(
+      id: json['id'] as String,
+      item: foodItem,
+      quantity: _toDouble(json['quantity']),
+      unit: UnitType.values.byName(json['unit'] as String),
+      preparation: json['preparation'] as String?,
+    );
+  }
+
+  FoodItem? _resolveFoodItem(String? itemId, Map<String, dynamic>? itemJson) {
+    if (itemJson != null) {
+      return FoodItem.fromJson(itemJson);
+    }
+    if (itemId != null) {
+      return SeedFoodRepository.instance.itemById(itemId);
+    }
+    return null;
+  }
+
+  double _toDouble(dynamic value) {
+    if (value is num) {
+      return value.toDouble();
+    }
+    if (value is String) {
+      return double.tryParse(value) ?? 0.0;
+    }
+    return 0.0;
+  }
+
+  int _toInt(dynamic value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    if (value is String) {
+      return int.tryParse(value) ?? 0;
+    }
+    return 0;
+  }
+
+  List<String> _stringList(dynamic value) {
+    if (value is List<dynamic>) {
+      return value.map((dynamic item) => item.toString()).toList();
+    }
+    return const <String>[];
+  }
+}

--- a/packages/features/recipes/pubspec.yaml
+++ b/packages/features/recipes/pubspec.yaml
@@ -5,9 +5,20 @@ publish_to: 'none'
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.13.0"
 
 dependencies:
-  # Add package dependencies here.
+  flutter:
+    sdk: flutter
+  core_kit:
+    path: ../../core_kit
+  nutrition_kit:
+    path: ../../nutrition_kit
+  meals_feature:
+    path: ../meals
+  path: ^1.9.0
 
 dev_dependencies:
-  # Add dev dependencies here.
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.3

--- a/packages/features/recipes/seed/recipes.json
+++ b/packages/features/recipes/seed/recipes.json
@@ -1,0 +1,151 @@
+{
+  "recipes": [
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "title": "Quinoa Power Bowl",
+      "description": "A hearty bowl with quinoa, chicken, and avocado.",
+      "nutrients": {
+        "calories": 520.0,
+        "protein": 36.0,
+        "fat": 18.0,
+        "carbohydrates": 52.0,
+        "fiber": 12.0,
+        "sugar": 6.0,
+        "sodium": 320.0
+      },
+      "servingSize": 1.0,
+      "servingUnit": "serving",
+      "ingredients": [
+        {
+          "id": "a1a1a1a1-a1a1-4a1a-a1a1-a1a1a1a1a1a1",
+          "itemId": "11111111-1111-1111-1111-111111111111",
+          "quantity": 1.0,
+          "unit": "cup",
+          "preparation": "cooked"
+        },
+        {
+          "id": "b2b2b2b2-b2b2-4b2b-b2b2-b2b2b2b2b2b2",
+          "itemId": "22222222-2222-2222-2222-222222222222",
+          "quantity": 150.0,
+          "unit": "gram",
+          "preparation": "sliced"
+        },
+        {
+          "id": "c3c3c3c3-c3c3-4c3c-c3c3-c3c3c3c3c3c3",
+          "itemId": "33333333-3333-3333-3333-333333333333",
+          "quantity": 0.5,
+          "unit": "piece",
+          "preparation": "sliced"
+        }
+      ],
+      "instructions": [
+        "Cook quinoa according to package instructions.",
+        "Slice grilled chicken and avocado.",
+        "Combine ingredients in a bowl and season to taste."
+      ],
+      "tags": ["high-protein", "gluten-free"],
+      "prepTimeMinutes": 15,
+      "cookTimeMinutes": 20,
+      "imageUrl": "https://example.com/images/quinoa-bowl.jpg",
+      "sourceUrl": "https://example.com/recipes/quinoa-power-bowl"
+    },
+    {
+      "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      "title": "Berry Yogurt Parfait",
+      "description": "Layered Greek yogurt with blueberries and granola.",
+      "nutrients": {
+        "calories": 280.0,
+        "protein": 20.0,
+        "fat": 5.0,
+        "carbohydrates": 38.0,
+        "fiber": 4.0,
+        "sugar": 22.0,
+        "sodium": 120.0
+      },
+      "servingSize": 1.0,
+      "servingUnit": "serving",
+      "ingredients": [
+        {
+          "id": "d4d4d4d4-d4d4-4d4d-d4d4-d4d4d4d4d4d4",
+          "itemId": "44444444-4444-4444-4444-444444444444",
+          "quantity": 1.0,
+          "unit": "cup",
+          "preparation": null
+        },
+        {
+          "id": "e5e5e5e5-e5e5-4e5e-e5e5-e5e5e5e5e5e5",
+          "itemId": "55555555-5555-5555-5555-555555555555",
+          "quantity": 0.5,
+          "unit": "cup",
+          "preparation": null
+        },
+        {
+          "id": "f6f6f6f6-f6f6-4f6f-f6f6-f6f6f6f6f6f6",
+          "itemId": "66666666-6666-6666-6666-666666666666",
+          "quantity": 0.25,
+          "unit": "cup",
+          "preparation": null
+        }
+      ],
+      "instructions": [
+        "Spoon half of the yogurt into a glass.",
+        "Add a layer of blueberries and granola.",
+        "Repeat the layers and serve immediately."
+      ],
+      "tags": ["breakfast", "vegetarian"],
+      "prepTimeMinutes": 10,
+      "cookTimeMinutes": 0,
+      "imageUrl": "https://example.com/images/berry-parfait.jpg",
+      "sourceUrl": "https://example.com/recipes/berry-yogurt-parfait"
+    },
+    {
+      "id": "cccccccc-cccc-cccc-cccc-cccccccccccc",
+      "title": "Avocado Toast Deluxe",
+      "description": "Toasted whole grain bread topped with smashed avocado and yogurt drizzle.",
+      "nutrients": {
+        "calories": 430.0,
+        "protein": 16.0,
+        "fat": 24.0,
+        "carbohydrates": 40.0,
+        "fiber": 11.0,
+        "sugar": 6.0,
+        "sodium": 520.0
+      },
+      "servingSize": 1.0,
+      "servingUnit": "serving",
+      "ingredients": [
+        {
+          "id": "g7g7g7g7-g7g7-4g7g-g7g7-g7g7g7g7g7g7",
+          "itemId": "77777777-7777-7777-7777-777777777777",
+          "quantity": 2.0,
+          "unit": "piece",
+          "preparation": "toasted"
+        },
+        {
+          "id": "h8h8h8h8-h8h8-4h8h-h8h8-h8h8h8h8h8h8",
+          "itemId": "33333333-3333-3333-3333-333333333333",
+          "quantity": 1.0,
+          "unit": "piece",
+          "preparation": "smashed"
+        },
+        {
+          "id": "i9i9i9i9-i9i9-4i9i-i9i9-i9i9i9i9i9i9",
+          "itemId": "44444444-4444-4444-4444-444444444444",
+          "quantity": 2.0,
+          "unit": "tablespoon",
+          "preparation": "mixed with lemon"
+        }
+      ],
+      "instructions": [
+        "Toast the bread slices until golden brown.",
+        "Mash the avocado with salt, pepper, and lemon juice.",
+        "Spread the avocado on the toast and drizzle with yogurt mixture."
+      ],
+      "tags": ["vegetarian", "brunch"],
+      "prepTimeMinutes": 12,
+      "cookTimeMinutes": 5,
+      "imageUrl": "https://example.com/images/avocado-toast.jpg",
+      "sourceUrl": "https://example.com/recipes/avocado-toast-deluxe"
+    }
+  ]
+}

--- a/packages/features/recipes/test/recipe_detail_screen_test.dart
+++ b/packages/features/recipes/test/recipe_detail_screen_test.dart
@@ -1,0 +1,203 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meals_feature/meals_feature.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:recipes_feature/recipes_feature.dart';
+
+class _MockMealsRepository extends Mock implements MealsRepository {}
+
+class _FakeMealEntry extends Fake implements MealEntry {}
+
+void main() {
+  late MealsRepository mealsRepository;
+  late Recipe recipe;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeMealEntry());
+  });
+
+  setUp(() {
+    mealsRepository = _MockMealsRepository();
+    recipe = _buildRecipe();
+  });
+
+  testWidgets('scales ingredients and nutrients when servings change',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RecipeDetailScreen(
+          recipe: recipe,
+          mealsRepository: mealsRepository,
+          mealType: MealType.lunch,
+          consumedAt: DateTime(2024, 1, 10, 12),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.textContaining('100 g'), findsOneWidget);
+    expect(find.textContaining('50 g'), findsOneWidget);
+
+    final caloriesFinder = find.byKey(const Key('nutrient_calories_value'));
+    final proteinFinder = find.byKey(const Key('nutrient_protein_value'));
+    final carbsFinder = find.byKey(const Key('nutrient_carbs_value'));
+    final fatFinder = find.byKey(const Key('nutrient_fat_value'));
+
+    expect(
+      tester.widget<Text>(caloriesFinder).data,
+      '260 kcal',
+    );
+    expect(
+      tester.widget<Text>(proteinFinder).data,
+      '13 g',
+    );
+    expect(
+      tester.widget<Text>(carbsFinder).data,
+      '25 g',
+    );
+    expect(
+      tester.widget<Text>(fatFinder).data,
+      '7 g',
+    );
+
+    final incrementButton = find.descendant(
+      of: find.byType(QuantityStepper),
+      matching: find.byIcon(Icons.add),
+    );
+
+    await tester.tap(incrementButton);
+    await tester.pump();
+
+    expect(find.textContaining('125 g'), findsOneWidget);
+    expect(find.textContaining('62.5 g'), findsOneWidget);
+
+    expect(
+      tester.widget<Text>(caloriesFinder).data,
+      '325 kcal',
+    );
+    expect(
+      tester.widget<Text>(proteinFinder).data,
+      '16.3 g',
+    );
+    expect(
+      tester.widget<Text>(carbsFinder).data,
+      '31.3 g',
+    );
+    expect(
+      tester.widget<Text>(fatFinder).data,
+      '8.8 g',
+    );
+  });
+
+  testWidgets('adds the scaled recipe as a meal entry', (tester) async {
+    when(() => mealsRepository.upsertMeal(any())).thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RecipeDetailScreen(
+          recipe: recipe,
+          mealsRepository: mealsRepository,
+          mealType: MealType.dinner,
+          consumedAt: DateTime(2024, 1, 10, 20),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    final incrementButton = find.descendant(
+      of: find.byType(QuantityStepper),
+      matching: find.byIcon(Icons.add),
+    );
+
+    await tester.tap(incrementButton);
+    await tester.pump();
+
+    await tester.tap(find.text('Aggiungi al pasto'));
+    await tester.pump();
+
+    final captured =
+        verify(() => mealsRepository.upsertMeal(captureAny())).captured.single
+            as MealEntry;
+
+    expect(captured.recipeId, recipe.id);
+    expect(captured.mealType, MealType.dinner);
+    expect(captured.servings, 2.5);
+    expect(captured.ingredients, hasLength(2));
+    expect(captured.ingredients.first.quantity, closeTo(125, 0.001));
+    expect(captured.ingredients.last.quantity, closeTo(62.5, 0.001));
+  });
+}
+
+Recipe _buildRecipe() {
+  final firstItem = FoodItem(
+    id: 'food-1',
+    name: 'Ingrediente principale',
+    nutrients: const Nutrients(
+      calories: 200,
+      protein: 10,
+      fat: 5,
+      carbohydrates: 20,
+      fiber: 4,
+      sugar: 6,
+      sodium: 100,
+    ),
+    servingSize: 100,
+    servingUnit: UnitType.gram,
+  );
+
+  final secondItem = FoodItem(
+    id: 'food-2',
+    name: 'Ingrediente secondario',
+    nutrients: const Nutrients(
+      calories: 120,
+      protein: 6,
+      fat: 4,
+      carbohydrates: 10,
+      fiber: 2,
+      sugar: 3,
+      sodium: 80,
+    ),
+    servingSize: 100,
+    servingUnit: UnitType.gram,
+  );
+
+  return Recipe(
+    id: 'recipe-1',
+    title: 'Ricetta di prova',
+    description: 'Una ricetta utilizzata per i test.',
+    nutrients: const Nutrients(
+      calories: 0,
+      protein: 0,
+      fat: 0,
+      carbohydrates: 0,
+      fiber: 0,
+      sugar: 0,
+      sodium: 0,
+    ),
+    servingSize: 2,
+    servingUnit: UnitType.serving,
+    ingredients: [
+      Ingredient(
+        id: 'ing-1',
+        item: firstItem,
+        quantity: 100,
+        unit: UnitType.gram,
+        preparation: 'grigliato',
+      ),
+      Ingredient(
+        id: 'ing-2',
+        item: secondItem,
+        quantity: 50,
+        unit: UnitType.gram,
+        preparation: 'tritato',
+      ),
+    ],
+    instructions: const ['Step 1'],
+    tags: const ['test'],
+    prepTimeMinutes: 10,
+    cookTimeMinutes: 5,
+  );
+}


### PR DESCRIPTION
## Summary
- add a seed-based repository that exposes the bundled recipe catalog
- implement the recipe detail screen with serving scaling, nutrient totals and meal logging
- add widget coverage to verify nutrient recalculation and repository integration

## Testing
- flutter test packages/features/recipes/test/recipe_detail_screen_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cff21b8404832fa270af1b8b13da05