### PR TITLE
Add heuristic meal recommender

### DIFF
--- a/packages/recommender_kit/lib/recommender_kit.dart
+++ b/packages/recommender_kit/lib/recommender_kit.dart
@@ -1,0 +1,5 @@
+library recommender_kit;
+
+export 'src/recommender.dart';
+export 'src/heuristic_recommender.dart';
+export 'src/feedback.dart';

--- a/packages/recommender_kit/lib/src/feedback.dart
+++ b/packages/recommender_kit/lib/src/feedback.dart
@@ -1,0 +1,53 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:core_kit/src/drift/drift_database.dart';
+import 'package:data_kit/data_kit.dart';
+import 'package:drift/drift.dart';
+
+/// Stores user feedback as an [EventLog] entry in the shared database.
+Future<void> recordFeedback(EventLog event) async {
+  final AppDatabase db = await initDatabase();
+  await db.into(db.eventLogs).insert(
+        _MapInsertable(db.eventLogToColumns(event)),
+        mode: InsertMode.insertOrReplace,
+      );
+}
+
+class _MapInsertable implements Insertable<dynamic> {
+  _MapInsertable(this.values);
+
+  final Map<String, dynamic> values;
+
+  @override
+  Map<String, Expression<Object?>> toColumns(bool nullToAbsent) {
+    final mapped = <String, Expression<Object?>>{};
+    values.forEach((key, value) {
+      if (value == null && nullToAbsent) {
+        return;
+      }
+      mapped[key] = _wrapValue(value);
+    });
+    return mapped;
+  }
+}
+
+Expression<Object?> _wrapValue(dynamic value) {
+  if (value is int) {
+    return Variable<int>(value);
+  }
+  if (value is double) {
+    return Variable<double>(value);
+  }
+  if (value is bool) {
+    return Variable<bool>(value);
+  }
+  if (value is String) {
+    return Variable<String>(value);
+  }
+  if (value is DateTime) {
+    return Variable<DateTime>(value);
+  }
+  if (value is num) {
+    return Variable<double>(value.toDouble());
+  }
+  return Variable<Object?>(value);
+}

--- a/packages/recommender_kit/lib/src/heuristic_recommender.dart
+++ b/packages/recommender_kit/lib/src/heuristic_recommender.dart
@@ -1,0 +1,388 @@
+import 'dart:math';
+
+import 'package:collection/collection.dart';
+import 'package:core_kit/core_kit.dart';
+
+import 'recommender.dart';
+
+/// Simple rule-based recommender that balances nutritional targets while
+/// respecting dietary restrictions and recent meal history.
+class HeuristicRecommender implements Recommender {
+  const HeuristicRecommender();
+
+  static const int _maxSuggestions = 3;
+
+  @override
+  Future<List<MealSuggestion>> recommend(SuggestionContext context) async {
+    final filtered = _filterCandidates(context);
+    if (filtered.isEmpty) {
+      return <MealSuggestion>[];
+    }
+
+    final Set<String> recentIds = _recentRecipeIds(context);
+
+    final suggestions = filtered
+        .map(
+          (recipe) => MealSuggestion(
+            recipe: recipe,
+            score: _scoreRecipe(
+              recipe,
+              context,
+              isRecent: recentIds.contains(recipe.id),
+            ),
+            reason: _buildReason(
+              recipe,
+              context,
+              isRecent: recentIds.contains(recipe.id),
+            ),
+          ),
+        )
+        .toList();
+
+    suggestions.sort((a, b) => b.score.compareTo(a.score));
+
+    final result = <MealSuggestion>[];
+    for (final suggestion in suggestions) {
+      if (result.length >= _maxSuggestions) {
+        break;
+      }
+      if (recentIds.contains(suggestion.recipe.id)) {
+        continue;
+      }
+      result.add(suggestion);
+    }
+
+    if (result.length < _maxSuggestions) {
+      for (final suggestion in suggestions) {
+        if (result.length >= _maxSuggestions) {
+          break;
+        }
+        if (result.any((s) => s.recipe.id == suggestion.recipe.id)) {
+          continue;
+        }
+        result.add(suggestion);
+      }
+    }
+
+    return result;
+  }
+}
+
+List<Recipe> _filterCandidates(SuggestionContext context) {
+  return context.candidates.where((recipe) {
+    if (!_matchesDiet(recipe, context.profile.preferredDiet)) {
+      return false;
+    }
+    if (_containsAllergens(recipe, context.profile.allergies)) {
+      return false;
+    }
+    if (_containsDisliked(recipe, context.profile.dislikedIngredients)) {
+      return false;
+    }
+    return true;
+  }).toList();
+}
+
+Set<String> _recentRecipeIds(SuggestionContext context) {
+  if (context.recentMeals.isEmpty) {
+    return <String>{};
+  }
+  final threshold = context.referenceTime.subtract(context.recentMealWindow);
+  return context.recentMeals
+      .where((meal) => meal.recipeId != null && meal.consumedAt.isAfter(threshold))
+      .map((meal) => meal.recipeId!)
+      .toSet();
+}
+
+const Map<DietModel, Set<String>> _dietTags = <DietModel, Set<String>>{
+  DietModel.vegetarian: {'vegetarian'},
+  DietModel.vegan: {'vegan'},
+  DietModel.pescetarian: {'pescetarian', 'seafood'},
+  DietModel.keto: {'keto', 'low-carb', 'low carb'},
+  DietModel.paleo: {'paleo'},
+  DietModel.mediterranean: {'mediterranean'},
+  DietModel.glutenFree: {'gluten-free', 'gluten free'},
+};
+
+const Set<String> _meatKeywords = <String>{
+  'bacon',
+  'beef',
+  'chicken',
+  'ham',
+  'lamb',
+  'pancetta',
+  'pork',
+  'prosciutto',
+  'salami',
+  'sausage',
+  'steak',
+  'turkey',
+  'veal',
+};
+
+const Set<String> _seafoodKeywords = <String>{
+  'anchovy',
+  'cod',
+  'fish',
+  'mackerel',
+  'prawn',
+  'salmon',
+  'shrimp',
+  'tuna',
+};
+
+const Set<String> _animalProductKeywords = <String>{
+  'butter',
+  'cheese',
+  'egg',
+  'gelatin',
+  'honey',
+  'milk',
+  'yogurt',
+};
+
+const Set<String> _grainKeywords = <String>{
+  'barley',
+  'bread',
+  'bulgur',
+  'cereal',
+  'corn',
+  'couscous',
+  'farro',
+  'noodle',
+  'oat',
+  'pasta',
+  'rice',
+  'rye',
+  'spelt',
+  'wheat',
+};
+
+const Set<String> _glutenKeywords = <String>{
+  'barley',
+  'farro',
+  'gluten',
+  'rye',
+  'spelt',
+  'wheat',
+};
+
+const Set<String> _highCarbKeywords = <String>{
+  'bread',
+  'pasta',
+  'potato',
+  'rice',
+  'sugar',
+};
+
+bool _matchesDiet(Recipe recipe, DietModel diet) {
+  final tags = _normalizedRecipeTags(recipe);
+  final tagMatches = _dietTags[diet];
+  if (tagMatches != null && tags.any(tagMatches.contains)) {
+    return true;
+  }
+
+  switch (diet) {
+    case DietModel.omnivore:
+      return true;
+    case DietModel.vegetarian:
+      return !_containsAny(recipe, _meatKeywords) &&
+          !_containsAny(recipe, _seafoodKeywords);
+    case DietModel.vegan:
+      return _matchesDiet(recipe, DietModel.vegetarian) &&
+          !_containsAny(recipe, _animalProductKeywords);
+    case DietModel.pescetarian:
+      return !_containsAny(recipe, _meatKeywords);
+    case DietModel.keto:
+      if (recipe.nutrients.carbohydrates > 25) {
+        return false;
+      }
+      return !_containsAny(recipe, _highCarbKeywords);
+    case DietModel.paleo:
+      return !_containsAny(recipe, _grainKeywords) &&
+          !_containsAny(recipe, _highCarbKeywords);
+    case DietModel.mediterranean:
+      return true;
+    case DietModel.glutenFree:
+      return !_containsAllergenKeyword(recipe, 'gluten') &&
+          !_containsAny(recipe, _glutenKeywords);
+  }
+}
+
+bool _containsAllergens(Recipe recipe, Iterable<String> allergies) {
+  final targets = allergies
+      .map((value) => value.trim().toLowerCase())
+      .where((value) => value.isNotEmpty)
+      .toSet();
+  if (targets.isEmpty) {
+    return false;
+  }
+
+  for (final ingredient in recipe.ingredients) {
+    final item = ingredient.item;
+    for (final allergen in item.allergens) {
+      final normalized = allergen.toLowerCase();
+      if (targets.any((needle) => normalized.contains(needle))) {
+        return true;
+      }
+    }
+    final name = item.name.toLowerCase();
+    if (targets.any(name.contains)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _containsDisliked(Recipe recipe, Iterable<String> disliked) {
+  final targets = disliked
+      .map((value) => value.trim().toLowerCase())
+      .where((value) => value.isNotEmpty)
+      .toSet();
+  if (targets.isEmpty) {
+    return false;
+  }
+
+  final ingredientNames = recipe.ingredients
+      .map((ingredient) => ingredient.item.name.toLowerCase())
+      .toList();
+  final tags = _normalizedRecipeTags(recipe);
+
+  for (final target in targets) {
+    if (ingredientNames.any((name) => name.contains(target))) {
+      return true;
+    }
+    if (tags.any((tag) => tag.contains(target))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _containsAny(Recipe recipe, Set<String> keywords) {
+  if (keywords.isEmpty) {
+    return false;
+  }
+  final names = recipe.ingredients
+      .map((ingredient) => ingredient.item.name.toLowerCase())
+      .toList();
+  final tags = _normalizedRecipeTags(recipe);
+  return keywords.any(
+    (keyword) =>
+        names.any((name) => name.contains(keyword)) ||
+        tags.any((tag) => tag.contains(keyword)),
+  );
+}
+
+bool _containsAllergenKeyword(Recipe recipe, String keyword) {
+  final target = keyword.toLowerCase();
+  for (final ingredient in recipe.ingredients) {
+    for (final allergen in ingredient.item.allergens) {
+      if (allergen.toLowerCase().contains(target)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+Set<String> _normalizedRecipeTags(Recipe recipe) {
+  final tags = <String>{};
+  tags.addAll(recipe.tags.map((tag) => tag.toLowerCase()));
+  for (final ingredient in recipe.ingredients) {
+    tags.addAll(ingredient.item.tags.map((tag) => tag.toLowerCase()));
+  }
+  return tags;
+}
+
+Nutrients _addNutrients(Nutrients a, Nutrients b) {
+  return Nutrients(
+    calories: a.calories + b.calories,
+    protein: a.protein + b.protein,
+    fat: a.fat + b.fat,
+    carbohydrates: a.carbohydrates + b.carbohydrates,
+    fiber: a.fiber + b.fiber,
+    sugar: a.sugar + b.sugar,
+    sodium: a.sodium + b.sodium,
+  );
+}
+
+Map<String, double> _macroDifferences(Nutrients actual, Nutrients target) {
+  return <String, double>{
+    'calorie': _normalizedDiff(actual.calories, target.calories),
+    'proteine': _normalizedDiff(actual.protein, target.protein),
+    'grassi': _normalizedDiff(actual.fat, target.fat),
+    'carboidrati': _normalizedDiff(actual.carbohydrates, target.carbohydrates),
+  };
+}
+
+double _normalizedDiff(double actual, double target) {
+  final double denominator = max(target.abs(), 1.0);
+  return (actual - target).abs() / denominator;
+}
+
+double _scoreRecipe(
+  Recipe recipe,
+  SuggestionContext context, {
+  required bool isRecent,
+}) {
+  final combined = _addNutrients(context.consumedMacros, recipe.nutrients);
+  final after = _macroDifferences(combined, context.targetMacros);
+  final before = _macroDifferences(context.consumedMacros, context.targetMacros);
+
+  final double sumAfter = after.values.sum;
+  final double sumBefore = before.values.sum;
+  final double improvement = (sumBefore - sumAfter).clamp(-1.0, 1.0);
+  final double balance = 1 / (1 + sumAfter);
+
+  final double dietAffinity = _dietAffinity(recipe, context.profile.preferredDiet);
+  final double mealTypeAffinity = _mealTypeAffinity(recipe, context.mealType);
+
+  double score = balance + improvement + dietAffinity + mealTypeAffinity;
+  score += isRecent ? -0.5 : 0.2;
+  return max(score, 0);
+}
+
+double _dietAffinity(Recipe recipe, DietModel diet) {
+  final tags = _normalizedRecipeTags(recipe);
+  final tagMatches = _dietTags[diet];
+  if (tagMatches == null) {
+    return 0;
+  }
+  return tags.any(tagMatches.contains) ? 0.15 : 0;
+}
+
+double _mealTypeAffinity(Recipe recipe, MealType mealType) {
+  final tags = _normalizedRecipeTags(recipe);
+  return tags.contains(mealType.name) ? 0.1 : 0;
+}
+
+String _buildReason(
+  Recipe recipe,
+  SuggestionContext context, {
+  required bool isRecent,
+}) {
+  final combined = _addNutrients(context.consumedMacros, recipe.nutrients);
+  final after = _macroDifferences(combined, context.targetMacros);
+  final before = _macroDifferences(context.consumedMacros, context.targetMacros);
+
+  final improvements = <String, double>{};
+  after.forEach((macro, value) {
+    final previous = before[macro] ?? value;
+    improvements[macro] = previous - value;
+  });
+
+  final best = improvements.entries
+      .sorted((a, b) => b.value.compareTo(a.value))
+      .first;
+
+  if (best.value > 0.05) {
+    return 'Riduce lo scostamento di ${best.key} rispetto al target.';
+  }
+
+  if (!isRecent) {
+    return 'Aggiunge varietà rispetto ai pasti recenti.';
+  }
+
+  return 'Bilanciamento nutrizionale stabile.';
+}

--- a/packages/recommender_kit/lib/src/recommender.dart
+++ b/packages/recommender_kit/lib/src/recommender.dart
@@ -1,0 +1,72 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:meta/meta.dart';
+
+/// Describes the context in which meal suggestions should be generated.
+///
+/// It contains the user profile, available recipes, nutritional targets
+/// and recent meal history so that a recommender can make informed choices.
+@immutable
+class SuggestionContext {
+  const SuggestionContext({
+    required this.profile,
+    required this.mealType,
+    required List<Recipe> candidates,
+    required this.targetMacros,
+    this.consumedMacros = const Nutrients(),
+    List<MealEntry> recentMeals = const <MealEntry>[],
+    DateTime? referenceTime,
+    this.recentMealWindow = const Duration(days: 2),
+  })  : candidates = List<Recipe>.unmodifiable(candidates),
+        recentMeals = List<MealEntry>.unmodifiable(recentMeals),
+        referenceTime = referenceTime ?? DateTime.now();
+
+  /// The profile to tailor meal suggestions for.
+  final UserProfile profile;
+
+  /// The meal that should be planned, e.g. breakfast or dinner.
+  final MealType mealType;
+
+  /// Candidate recipes to choose from.
+  final List<Recipe> candidates;
+
+  /// The nutrient target that the recommendation should aim for when the meal
+  /// is included in the user's plan.
+  final Nutrients targetMacros;
+
+  /// Nutrients that have already been consumed for the day.
+  final Nutrients consumedMacros;
+
+  /// Meals logged recently. Used to diversify the output.
+  final List<MealEntry> recentMeals;
+
+  /// Reference time used to evaluate the recency of meals.
+  final DateTime referenceTime;
+
+  /// Window of time to consider a meal as "recent".
+  final Duration recentMealWindow;
+}
+
+/// Describes a suggestion returned by a [Recommender].
+@immutable
+class MealSuggestion {
+  const MealSuggestion({
+    required this.recipe,
+    required this.score,
+    required this.reason,
+  });
+
+  /// Recipe that should be suggested to the user.
+  final Recipe recipe;
+
+  /// Heuristic score. Higher scores represent better matches.
+  final double score;
+
+  /// Human readable explanation of why the recipe was suggested.
+  final String reason;
+}
+
+/// Contract implemented by meal recommendation strategies.
+abstract class Recommender {
+  /// Returns a ranked list of meal suggestions based on the provided [context].
+  Future<List<MealSuggestion>> recommend(SuggestionContext context);
+}

--- a/packages/recommender_kit/pubspec.yaml
+++ b/packages/recommender_kit/pubspec.yaml
@@ -1,5 +1,5 @@
 name: recommender_kit
-description: Recommendation engine tools for Assistente Alimentare.
+description: Recommendation engine tools for the Assistente Alimentare project.
 version: 0.1.0
 publish_to: 'none'
 
@@ -7,7 +7,13 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  # Add package dependencies here.
+  core_kit:
+    path: ../core_kit
+  data_kit:
+    path: ../data_kit
+  collection: ^1.18.0
+  meta: ^1.10.0
+  drift: ^2.15.0
 
 dev_dependencies:
-  # Add dev dependencies here.
+  test: ^1.25.2

--- a/packages/recommender_kit/test/heuristic_recommender_test.dart
+++ b/packages/recommender_kit/test/heuristic_recommender_test.dart
@@ -1,0 +1,271 @@
+import 'package:core_kit/core_kit.dart';
+import 'package:data_kit/data_kit.dart';
+import 'package:drift/drift.dart';
+import 'package:recommender_kit/recommender_kit.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HeuristicRecommender', () {
+    late HeuristicRecommender recommender;
+
+    setUp(() {
+      recommender = const HeuristicRecommender();
+    });
+
+    test('rispetta dieta, allergie e ingredienti sgraditi', () async {
+      final profile = UserProfile.create(
+        name: 'Test',
+        preferredDiet: DietModel.vegetarian,
+        dailyCalorieTarget: 2000,
+        heightCm: 170,
+        weightKg: 68,
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+        allergies: const ['Peanuts'],
+        dislikedIngredients: const ['mushroom'],
+      );
+
+      final chickpea = FoodItem.create(
+        name: 'Chickpeas',
+        nutrients: const Nutrients(
+          calories: 220,
+          protein: 12,
+          fat: 6,
+          carbohydrates: 34,
+        ),
+        servingSize: 100,
+        servingUnit: UnitType.gram,
+        tags: const ['vegetarian', 'dinner'],
+      );
+
+      final chicken = FoodItem.create(
+        name: 'Chicken Breast',
+        nutrients: const Nutrients(calories: 165, protein: 31, fat: 4, carbohydrates: 0),
+        servingSize: 100,
+        servingUnit: UnitType.gram,
+        tags: const ['meat'],
+      );
+
+      final peanuts = FoodItem.create(
+        name: 'Peanuts',
+        nutrients: const Nutrients(calories: 300, protein: 13, fat: 26, carbohydrates: 8),
+        servingSize: 50,
+        servingUnit: UnitType.gram,
+        allergens: const ['peanuts'],
+      );
+
+      final mushroom = FoodItem.create(
+        name: 'Mushroom',
+        nutrients: const Nutrients(calories: 20, protein: 3, fat: 0, carbohydrates: 2),
+        servingSize: 50,
+        servingUnit: UnitType.gram,
+      );
+
+      final safeRecipe = Recipe.create(
+        title: 'Zuppa di ceci',
+        description: 'Zuppa calda e proteica.',
+        nutrients: const Nutrients(
+          calories: 450,
+          protein: 20,
+          fat: 10,
+          carbohydrates: 60,
+        ),
+        servingSize: 1,
+        servingUnit: UnitType.serving,
+        ingredients: [
+          Ingredient.create(item: chickpea, quantity: 150, unit: UnitType.gram),
+        ],
+        tags: const ['vegetarian', 'dinner'],
+      );
+
+      final meatRecipe = Recipe.create(
+        title: 'Pollo grigliato',
+        description: 'Ricco di proteine.',
+        nutrients: const Nutrients(
+          calories: 350,
+          protein: 40,
+          fat: 6,
+          carbohydrates: 2,
+        ),
+        servingSize: 1,
+        servingUnit: UnitType.serving,
+        ingredients: [
+          Ingredient.create(item: chicken, quantity: 150, unit: UnitType.gram),
+        ],
+        tags: const ['lunch'],
+      );
+
+      final allergenRecipe = Recipe.create(
+        title: 'Pad thai alle arachidi',
+        description: 'Contiene frutta secca.',
+        nutrients: const Nutrients(
+          calories: 520,
+          protein: 18,
+          fat: 22,
+          carbohydrates: 60,
+        ),
+        servingSize: 1,
+        servingUnit: UnitType.serving,
+        ingredients: [
+          Ingredient.create(item: peanuts, quantity: 60, unit: UnitType.gram),
+        ],
+        tags: const ['dinner'],
+      );
+
+      final dislikedRecipe = Recipe.create(
+        title: 'Crema di funghi',
+        description: 'Sapori terrosi.',
+        nutrients: const Nutrients(
+          calories: 300,
+          protein: 10,
+          fat: 12,
+          carbohydrates: 30,
+        ),
+        servingSize: 1,
+        servingUnit: UnitType.serving,
+        ingredients: [
+          Ingredient.create(item: mushroom, quantity: 120, unit: UnitType.gram),
+        ],
+        tags: const ['dinner'],
+      );
+
+      final context = SuggestionContext(
+        profile: profile,
+        mealType: MealType.dinner,
+        candidates: [safeRecipe, meatRecipe, allergenRecipe, dislikedRecipe],
+        targetMacros: const Nutrients(
+          calories: 600,
+          protein: 25,
+          fat: 20,
+          carbohydrates: 70,
+        ),
+        consumedMacros: const Nutrients(
+          calories: 200,
+          protein: 8,
+          fat: 5,
+          carbohydrates: 25,
+        ),
+      );
+
+      final suggestions = await recommender.recommend(context);
+
+      expect(suggestions, hasLength(1));
+      expect(suggestions.single.recipe.title, 'Zuppa di ceci');
+      expect(suggestions.single.reason, isNotEmpty);
+    });
+
+    test('evita ripetizioni recenti quando ci sono alternative', () async {
+      final profile = UserProfile.create(
+        name: 'Mario',
+        preferredDiet: DietModel.omnivore,
+        dailyCalorieTarget: 2200,
+        heightCm: 175,
+        weightKg: 75,
+        createdAt: DateTime.utc(2024, 1, 1),
+        updatedAt: DateTime.utc(2024, 1, 1),
+      );
+
+      Recipe buildRecipe(String id, String title, double calories) {
+        return Recipe.create(
+          id: id,
+          title: title,
+          description: 'Ricetta $title',
+          nutrients: Nutrients(
+            calories: calories,
+            protein: 20,
+            fat: 12,
+            carbohydrates: 45,
+          ),
+          servingSize: 1,
+          servingUnit: UnitType.serving,
+          ingredients: [
+            Ingredient.create(
+              item: FoodItem.create(
+                name: title,
+                nutrients: Nutrients(calories: calories, protein: 10, fat: 5, carbohydrates: 20),
+                servingSize: 1,
+                servingUnit: UnitType.serving,
+                tags: const ['lunch'],
+              ),
+              quantity: 1,
+              unit: UnitType.serving,
+            ),
+          ],
+          tags: const ['lunch'],
+        );
+      }
+
+      final recipes = [
+        buildRecipe('a', 'Insalata di quinoa', 420),
+        buildRecipe('b', 'Pasta al pesto', 550),
+        buildRecipe('c', 'Zuppa di lenticchie', 380),
+        buildRecipe('d', 'Tofu saltato', 400),
+      ];
+
+      final now = DateTime.utc(2024, 1, 10, 12);
+      final context = SuggestionContext(
+        profile: profile,
+        mealType: MealType.lunch,
+        candidates: recipes,
+        targetMacros: const Nutrients(
+          calories: 650,
+          protein: 30,
+          fat: 25,
+          carbohydrates: 80,
+        ),
+        consumedMacros: const Nutrients(
+          calories: 500,
+          protein: 22,
+          fat: 15,
+          carbohydrates: 55,
+        ),
+        recentMeals: [
+          MealEntry.create(
+            mealType: MealType.lunch,
+            consumedAt: now.subtract(const Duration(hours: 6)),
+            recipeId: 'a',
+          ),
+        ],
+        referenceTime: now,
+      );
+
+      final suggestions = await recommender.recommend(context);
+
+      expect(suggestions, hasLength(3));
+      expect(suggestions.map((s) => s.recipe.id), isNot(contains('a')));
+    });
+  });
+
+  group('recordFeedback', () {
+    tearDown(() async {
+      await closeDatabase();
+    });
+
+    test('memorizza eventi nel registro', () async {
+      final db = await initDatabase(reset: true);
+      final event = EventLog.create(
+        timestamp: DateTime.utc(2024, 2, 1, 12),
+        type: 'feedback',
+        description: 'L\'utente apprezza la proposta.',
+        metadata: const {'rating': 5},
+        userId: 'user-123',
+      );
+
+      await recordFeedback(event);
+
+      final row = await db
+          .customSelect(
+            'SELECT * FROM event_logs WHERE id = ? LIMIT 1',
+            variables: [Variable<String>(event.id)],
+            readsFrom: {db.eventLogs},
+          )
+          .getSingleOrNull();
+
+      expect(row, isNotNull);
+      final stored = db.mapEventLog(Map<String, dynamic>.from(row!.data));
+      expect(stored.id, event.id);
+      expect(stored.type, 'feedback');
+      expect(stored.metadata['rating'], 5);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add the recommender kit public API with context and suggestion models
- implement a heuristic recommender that filters restrictions, balances macros and avoids recent meals
- persist feedback events through the shared data layer and cover behaviour with unit tests

## Testing
- Not run (dart/flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cff4201050832fb1845d3c848b8855